### PR TITLE
Implemented retrieval toggling for llama-index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+run.bash
+
+venv/
+__pycache__/


### PR DESCRIPTION
Implemented retrieval toggle functionality for llama_index algorithm

Retrieval is enabled by default and can be disabled with the algorithm-kwargs command-line argument:

`--algorithm-kwargs '{"domain_docs_dir": "../data/DomainDocumentsPDF", "retrieval_enabled": false}' `