### PR TITLE
Fix minor bug in Llama-2 Single KDMA ADM When Answer is not integer

### DIFF
--- a/align_system/algorithms/llama_2_single_kdma_adm.py
+++ b/align_system/algorithms/llama_2_single_kdma_adm.py
@@ -954,7 +954,11 @@ class Llama2SingleKDMAADM(AlignedDecisionMaker):
                 raw_treatment_response, ['Reasoning', 'Answer', 'Location'])  # noqa
 
             if parsed_treatment_output is not None:
-                treatment_idx = parsed_treatment_output['Answer']
+                try:
+                    treatment_idx = int(parsed_treatment_output['Answer'])
+                except ValueError:
+                    log.warning('** Treatment index not an integer, retrying!')
+                    continue
 
                 if len(available_supplies) <= treatment_idx:
                     log.info('** Selected treatment_idx out of range of '


### PR DESCRIPTION
When the answer to a parsed treatment output is not an integer (can sometimes happen with the LLM), instead of failing on L959, try to parse the answer into an integer (and retry if impossible). 