### PR TITLE
Updated START tagging ADM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 This changelog follows the specifications detailed in: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), although we have not yet reached a `1.0.0` release.
 
+## Unreleased
+
+### Changed
+
+* Modified the prompt for PulseTaggingADM. Also removed duplicated inference call within `identify_tag_color`
+  method. Additionally, removed duplicated RED tag in-context example and replaced with missing BLACK tag
+  example.
+
 ## 0.3.2
 
 ### Fixed


### PR DESCRIPTION
- Modified prompt
- Removed duplicated RED tag example, replaced with missing BLACK tag example
- Removed duplicated inference call in `identify_tag_color`