### PR TITLE
Outlines Regression ADM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+* Fixed issue with outlines ADM by catching when target KDMAs are not formatted as dictionaries as expected during eval sessions
 * Fixed issue with outlines ADM where responses weren't a list when only a single sample was requested
 
 ### Added
 
+* Added new implementation of multi-KDMA ADM that regresses KDMA scores based on the outlines structure called `outlines_regression_adm`
+* Added regression prompts to `align_system/prompt_engineering/outlines_prompts.py`
+* Added KDMA descriptions to `align_system/prompt_engineering/kdma_descriptions.yml`
 * Added new [Outlines](https://github.com/outlines-dev/outlines) based structured ADM
 * Added outlines based prompts (in `align_system/prompt_engineering/outlines_prompts.py`)
 * Added dedicated function to utils for calculating votes (same voting scheme as the single KDMA ADM)
 * Added top level config options to force determinism and fix seeds; along with an example experiment to demonstrate
+
+### Depricated 
+* The algorithm `align_system/algorithms/chat_kdma_predicting_adm.py` has been replaced by `align_system/algorithms/outlines_regression_adm.py`
+* The functionality in `align_system/algorithms/lib/chat/` is no longer being used
+* Files `align_system/algorithms/lib/templates/` have been replaced by `align_system/prompt_engineering/`
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Added dedicated function to utils for calculating votes (same voting scheme as the single KDMA ADM)
 * Added top level config options to force determinism and fix seeds; along with an example experiment to demonstrate
 
-### Depricated 
+### Deprecated 
 * The algorithm `align_system/algorithms/chat_kdma_predicting_adm.py` has been replaced by `align_system/algorithms/outlines_regression_adm.py`
 * The functionality in `align_system/algorithms/lib/chat/` is no longer being used
 * Files `align_system/algorithms/lib/templates/` have been replaced by `align_system/prompt_engineering/`

--- a/align_system/algorithms/outlines_adm.py
+++ b/align_system/algorithms/outlines_adm.py
@@ -132,8 +132,12 @@ class OutlinesTransformersADM(ActionBasedADM):
             if len(kdma_values) != 1:
                 raise RuntimeError("This ADM assumes a single KDMA target, aborting!")
 
-            kdma = kdma_values[0]['kdma']
-            value = kdma_values[0]['value']
+            kdma_value = kdma_values[0]
+            if not isinstance(kdma_value, dict):
+                kdma_value = kdma_value.to_dict()
+
+            kdma = kdma_value['kdma']
+            value = kdma_value['value']
             # Assumption here is that KDMA values range from 0-1
             negative_value = 1 - value
 

--- a/align_system/algorithms/outlines_regression_adm.py
+++ b/align_system/algorithms/outlines_regression_adm.py
@@ -202,7 +202,6 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
                                 available_actions,
                                 alignment_target,
                                 num_samples=1,
-                                shuffle_choices=False,
                                 predict_outcomes=False,
                                 distribution_matching='average',
                                 **kwargs):
@@ -267,23 +266,17 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
 
         # Sample multiple predictions
         for _ in range(num_samples):
-            # Shuffle
-            if shuffle_choices:
-                shuffled_choices = random.sample(choices, len(choices))
-            else:
-                shuffled_choices = choices
-
             # Predict outcome of selecting each choice - optional
             if predict_outcomes:
-                predicted_outcomes = self.predict_outcomes(scenario_description, shuffled_choices)
+                predicted_outcomes = self.predict_outcomes(scenario_description, choices)
                 # Save outcome predictions
                 for idx in range(len(choices)):
-                    predicted_kdma_values[shuffled_choices[idx]]['outcomes'].append(predicted_outcomes[idx]['predicted_outcome'])
+                    predicted_kdma_values[choices[idx]]['outcomes'].append(predicted_outcomes[idx]['predicted_outcome'])
             else:
                 predicted_outcomes = None
 
             # Predict kdma values
-            kdma_score_responses, response_keys = self.predict_kdma_scores(scenario_description, shuffled_choices, \
+            kdma_score_responses, response_keys = self.predict_kdma_scores(scenario_description, choices, \
                                                                             target_kdmas, predicted_outcomes)
             # Save predictions
             for idx in range(len(kdma_score_responses)):
@@ -311,7 +304,7 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
 
         # Set up simple diaolg to return for follow-ups
         alignment_system_prompt = regression_alignment_system_prompt(target_kdmas)
-        prompt = action_selection_prompt(scenario_description, shuffled_choices)
+        prompt = action_selection_prompt(scenario_description, choices)
         dialog = [{'role': 'system', 'content': alignment_system_prompt},
                   {'role': 'user', 'content': prompt}]
 

--- a/align_system/algorithms/outlines_regression_adm.py
+++ b/align_system/algorithms/outlines_regression_adm.py
@@ -1,0 +1,89 @@
+import json
+import random
+
+import outlines
+from rich.highlighter import JSONHighlighter
+from swagger_client.models import (
+    ActionTypeEnum
+)
+
+from align_system.utils import logging
+from align_system.algorithms.outlines_adm import OutlinesTransformersADM
+from align_system.prompt_engineering.outlines_prompts import (
+    scenario_state_description_1,
+    outcomes_system_prompt,
+    outcomes_prediction_prompt
+)
+
+log = logging.getLogger(__name__)
+JSON_HIGHLIGHTER = JSONHighlighter()
+
+class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
+    def __init__(self,
+                 model_name,
+                 device='auto',
+                 baseline=False,
+                 **kwargs):
+        self.baseline = baseline
+        self.model = outlines.models.transformers(
+            model_name,
+            device=device,
+            model_kwargs=kwargs.get('model_kwargs', {}),
+            tokenizer_kwargs=kwargs.get('tokenizer_kwargs', {}))
+
+
+    def top_level_choose_action(self,
+                                scenario_state,
+                                available_actions,
+                                alignment_target,
+                                num_samples=1,
+                                shuffle_choices=False,
+                                predict_outcomes=False,
+                                **kwargs):
+
+        scenario_description = scenario_state_description_1(scenario_state)
+
+        # Important that the choices stay in the same order as the
+        # available actions as we'll use the selected index later to
+        # map to the corresponding action
+        choices = [a.unstructured for a in available_actions]
+
+        if len(set(choices)) != len(choices):
+            log.warning("Unstructured text for available actions is not "
+                        "unique, appending action parameters to choices")
+
+            character_id_to_name = {c.id: c.name for c in scenario_state.characters}
+            # Important that the choices stay in the same order as the
+            # available actions as we'll use the selected index later to
+            # map to the corresponding action
+            choices = []
+            for a in available_actions:
+                if(a.action_type == ActionTypeEnum.APPLY_TREATMENT
+                   and a.parameters is not None and len(a.parameters) > 0):
+                    choices.append(detailed_unstructured_treatment_action_text(a, character_id_to_name))
+                elif(a.action_type == ActionTypeEnum.TAG_CHARACTER
+                     and a.parameters is not None and len(a.parameters) > 0):
+                    choices.append(detailed_unstructured_tagging_action_text(a, character_id_to_name))
+                else:
+                    # Not covering every possible case here, may need
+                    # to add more dedicated detailed prompts
+                    choices.append(a.unstructured)
+
+        kdma_values = alignment_target.kdma_values
+
+        for _ in range(num_samples):
+            if shuffle_choices:
+                shuffled_choices = random.sample(choices, len(choices))
+            else:
+                shuffled_choices = choices
+
+            if predict_outcomes:
+                outcomes_sys_prompt = outcomes_system_prompt()
+                predict_outcomes_prompt = outcomes_prediction_prompt(scenario_description, shuffled_choices)
+                dialog = [{'role': 'system', 'content': outcomes_sys_prompt},
+                          {'role': 'user', 'content': predict_outcomes_prompt}]
+
+        import IPython
+        IPython.embed()
+
+    

--- a/align_system/algorithms/outlines_regression_adm.py
+++ b/align_system/algorithms/outlines_regression_adm.py
@@ -129,7 +129,7 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
 
         log.info("[bold]*KDMA SCORE PREDICTION RESPONSE*[/bold]",
                  extra={"markup": True})
-        log.info(predicted_outcomes, extra={"highlighter": JSON_HIGHLIGHTER})
+        log.info(kdma_score_responses, extra={"highlighter": JSON_HIGHLIGHTER})
 
         return kdma_score_responses, response_keys
 

--- a/align_system/algorithms/outlines_regression_adm.py
+++ b/align_system/algorithms/outlines_regression_adm.py
@@ -1,6 +1,9 @@
 import json
 import random
 import itertools
+import os 
+import pathlib
+import yaml
 
 import outlines
 from rich.highlighter import JSONHighlighter
@@ -14,11 +17,20 @@ from align_system.prompt_engineering.outlines_prompts import (
     scenario_state_description_1,
     outcomes_system_prompt,
     outcome_prediction_prompt,
-    outcome_prediction_json_schema
+    outcome_prediction_json_schema,
+    kdma_score_prediction_system_prompt,
+    kdma_score_prediction_prompt,
+    kdma_score_prediction_json_schema
 )
 
 log = logging.getLogger(__name__)
 JSON_HIGHLIGHTER = JSONHighlighter()
+
+# TODO - make this configurable? 
+KDMA_DESCRIPTIONS_FILE_PATH = os.path.join(
+    pathlib.Path(__file__).parent.absolute(), '..',
+    'prompt_engineering/kdma_descriptions.yml')
+
 
 class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
     def __init__(self,
@@ -34,6 +46,116 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
             tokenizer_kwargs=kwargs.get('tokenizer_kwargs', {}))
 
 
+    # Returns a list of predicted outcomes corresponding to the list of choices
+    def predict_outcomes(self, scenario_description, choices):
+        outcome_dialogs = []
+        outcomes_sys_prompt = outcomes_system_prompt()
+
+        for choice in choices:
+            predict_outcome_prompt = outcome_prediction_prompt(scenario_description, choice)
+            outcome_dialogs.append([{'role': 'system', 'content': outcomes_sys_prompt},
+                        {'role': 'user', 'content': predict_outcome_prompt}])
+
+        # Need to set the whitespace_pattern to prevent the state
+        # machine from looping indefinitely in some cases, see:
+        # https://github.com/outlines-dev/outlines/issues/690#issuecomment-2102291934
+        outcome_generator = outlines.generate.json(
+            self.model,
+            outcome_prediction_json_schema(),
+            whitespace_pattern=r"[ ]?")
+
+        outcome_dialog_texts = [self.dialog_to_prompt(d) for d in
+            itertools.chain(outcome_dialogs)]
+
+        # List of {predicted_outcomes:}, one of each choice in order of choices
+        predicted_outcomes = outcome_generator(outcome_dialog_texts)
+
+        return predicted_outcomes
+
+    # Predicts kdma scores associated with each choice
+    # Outputs a list of ADM responses and a corresponding list of response keys:
+    #   kdma_score_responses = [{score:int, reasoning:str}, ...]
+    #   reponse_keys = [{kdma:str, choice:str}, ...]
+    def predict_kdma_scores(self, scenario_description, choices, target_kdmas, predicted_outcomes=None):
+        kdma_dialogs = []
+        response_keys = []
+        # loop over target kdmas
+        for target_kdma in target_kdmas:
+            kdma_score_sys_prompt = kdma_score_prediction_system_prompt(target_kdma['name'], target_kdma['description'])
+            # loop over choices
+            for choice_idx in range(len(choices)):
+                choice = choices[choice_idx]
+                if predicted_outcomes:
+                    outcome = predicted_outcomes[choice_idx]['predicted_outcome']
+                else:
+                    outcome = None
+                predict_kdma_prompt = kdma_score_prediction_prompt(scenario_description, choice, outcome, target_kdma['name'])
+                kdma_dialogs.append([{'role': 'system', 'content': kdma_score_sys_prompt},
+                            {'role': 'user', 'content': predict_kdma_prompt}])
+                response_keys.append({'kdma':target_kdma['kdma'], 'choice':choice})
+
+        # Need to set the whitespace_pattern to prevent the state
+        # machine from looping indefinitely in some cases, see:
+        # https://github.com/outlines-dev/outlines/issues/690#issuecomment-2102291934
+        kdma_score_generator = outlines.generate.json(
+            self.model,
+            kdma_score_prediction_json_schema(),
+            whitespace_pattern=r"[ ]?")
+
+        kdma_dialog_texts = [self.dialog_to_prompt(d) for d in
+            itertools.chain(kdma_dialogs)]
+
+        # List of {score:int, reasoning:str}
+        kdma_score_responses = kdma_score_generator(kdma_dialog_texts)
+
+        return kdma_score_responses, response_keys
+
+
+    # Select choice by first averaging score across samples,
+    # then selecting the one with minimal MSE to the target
+    def average_distribution_matching(self, predicted_kdma_values, target_kdmas):
+        # Get average of predicted scores
+        average_predictions_for_each_choice = []
+        choices = []
+        for choice in list(predicted_kdma_values.keys()):
+            choices.append(choice)
+            average_predictions = {}
+            for target_kdma in target_kdmas:
+                kdma = target_kdma['kdma']
+                samples = predicted_kdma_values[choice][kdma]['scores']
+                average_predictions[kdma] = sum(samples) / len(samples) 
+            average_predictions_for_each_choice.append(average_predictions)
+
+        # get target kdma values - assumed to be int, TODO 
+        target_kdma_values = {}
+        for target_kdma in target_kdmas:
+            target_kdma_values[target_kdma['kdma']]=target_kdma['value']
+
+        # mean square error
+        def mse(target_kdma_values, predicted_kdma_values):
+            kdmas = set(target_kdma_values.keys()) & set(predicted_kdma_values.keys())
+            if len(kdmas) == 0:
+                return 0
+            return sum([(target_kdma_values[kdma] - predicted_kdma_values[kdma])**2 for kdma in kdmas]) / len(kdmas)
+
+        # find index of min mse
+        choice_idx = 0
+        min_mse = float('inf')
+        for i in range(len(choices)):
+            mse_ = mse(target_kdma_values, average_predictions_for_each_choice[i])
+            if mse_ < min_mse:
+                min_mse = mse_
+                choice_idx = i
+        selected_choice = choices[choice_idx]
+
+        # For now return reasoning of first sample, TODO improve this
+        reasoning = ''
+        for kdma in list(target_kdma_values.keys()):
+            reasoning += predicted_kdma_values[selected_choice][kdma]['reasonings'][0] + ' '
+
+        return selected_choice, reasoning
+
+
     def top_level_choose_action(self,
                                 scenario_state,
                                 available_actions,
@@ -41,6 +163,7 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
                                 num_samples=1,
                                 shuffle_choices=False,
                                 predict_outcomes=False,
+                                distribution_matching='average',
                                 **kwargs):
 
         scenario_description = scenario_state_description_1(scenario_state)
@@ -71,9 +194,29 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
                     # to add more dedicated detailed prompts
                     choices.append(a.unstructured)
 
-        kdma_values = alignment_target.kdma_values
+        target_kdmas = alignment_target.kdma_values
 
-        # Loop over samples
+        # Get kdma names and descriptions 
+        with open(KDMA_DESCRIPTIONS_FILE_PATH, 'r') as f:
+            kdma_descriptions = yaml.load(f, Loader=yaml.FullLoader)
+        # Add names and descriptions to target_kdmas
+        for kdma_idx in range(len(target_kdmas)):
+            kdma = target_kdmas[kdma_idx]['kdma']
+            target_kdmas[kdma_idx]['name'] = kdma_descriptions[kdma]['name']
+            target_kdmas[kdma_idx]['description'] = kdma_descriptions[kdma]['description'] # TODO error if description is missing
+
+        predicted_kdma_values = {}      # Dictionary to save output for each choice to
+        for choice in choices:
+            predicted_kdma_values[choice] = {
+                'outcomes':[]           # List to add sampled outcome predictions to
+            }
+            for target_kdma in target_kdmas:
+                predicted_kdma_values[choice][target_kdma['kdma']] = {
+                    'scores':[],        # List to add sampled kdma scores to
+                    'reasonings':[]     # List to add sampled kdma score reasonings to
+                }
+
+        # Sample multiple predictions
         for _ in range(num_samples):
             # Shuffle
             if shuffle_choices:
@@ -83,32 +226,38 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
 
             # Predict outcome of selecting each choice - optional
             if predict_outcomes:
-                outcome_dialogs = []
-                outcomes_sys_prompt = outcomes_system_prompt()
-
-                for choice in shuffled_choices:
-                    predict_outcome_prompt = outcome_prediction_prompt(scenario_description, choice)
-                    outcome_dialogs.append([{'role': 'system', 'content': outcomes_sys_prompt},
-                                {'role': 'user', 'content': predict_outcome_prompt}])
-
-                # Need to set the whitespace_pattern to prevent the state
-                # machine from looping indefinitely in some cases, see:
-                # https://github.com/outlines-dev/outlines/issues/690#issuecomment-2102291934
-                outcome_generator = outlines.generate.json(
-                    self.model,
-                    outcome_prediction_json_schema(),
-                    whitespace_pattern=r"[ ]?")
-
-                outcome_dialog_texts = [self.dialog_to_prompt(d) for d in
-                    itertools.chain(outcome_dialogs)]
-
-                # List of {predicted_outcomes:}, one of each choice in order of shuffled_choices
-                predicted_outcomes = outcome_generator(outcome_dialog_texts)
-
+                predicted_outcomes = self.predict_outcomes(scenario_description, shuffled_choices)
+                # Save outcome predictions
+                for idx in range(len(choices)):
+                    predicted_kdma_values[shuffled_choices[idx]]['outcomes'].append(predicted_outcomes[idx]['predicted_outcome'])
             else:
                 predicted_outcomes = None
 
-            import IPython
-            IPython.embed()
-            # Predict KDMA values for each choice
-    
+            # Predict kdma values
+            kdma_score_responses, response_keys = self.predict_kdma_scores(scenario_description, shuffled_choices, \
+                                                                            target_kdmas, predicted_outcomes)
+            # Save predictions
+            for idx in range(len(kdma_score_responses)):
+                response = kdma_score_responses[idx]
+                kdma = response_keys[idx]['kdma']
+                choice = response_keys[idx]['choice']
+                predicted_kdma_values[choice][kdma]['scores'].append(response['score'])
+                predicted_kdma_values[choice][kdma]['reasonings'].append(response['reasoning'])
+
+            # TODO Logging
+
+        # Regress best choice
+        if distribution_matching == 'average':
+            selected_choice, random_justification = self.average_distribution_matching(predicted_kdma_values, target_kdmas)
+        else:
+            raise RuntimeError("Distribution matching function not recognized.")
+
+        log.info("[bold]*STRUCTURED RESPONSE*[/bold]",
+                 extra={"markup": True})
+        log.info(selected_choice, extra={"highlighter": JSON_HIGHLIGHTER})
+
+        selected_choice_idx = choices.index(selected_choice)
+        action_to_take = available_actions[selected_choice_idx]
+        action_to_take.justification = random_justification
+
+        return action_to_take, [] # TODO

--- a/align_system/configs/adm/outlines_regression_aligned.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned.yaml
@@ -6,6 +6,5 @@ instance:
 
 inference_kwargs:
   num_samples: 10
-  shuffle_choices: true
   predict_outcomes: true
   distribution_matching: average

--- a/align_system/configs/adm/outlines_regression_aligned.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned.yaml
@@ -5,7 +5,7 @@ instance:
   baseline: false
 
 inference_kwargs:
-  num_samples: 5
+  num_samples: 10
   shuffle_choices: true
   predict_outcomes: true
   distribution_matching: average

--- a/align_system/configs/adm/outlines_regression_aligned.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned.yaml
@@ -1,0 +1,10 @@
+instance:
+  _target_: align_system.algorithms.outlines_regression_adm.OutlinesTransformersRegressionADM
+
+  model_name: mistralai/Mistral-7B-Instruct-v0.2
+  baseline: false
+
+inference_kwargs:
+  num_samples: 5
+  shuffle_choices: true
+  predict_outcomes: true

--- a/align_system/configs/adm/outlines_regression_aligned.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned.yaml
@@ -8,3 +8,4 @@ inference_kwargs:
   num_samples: 5
   shuffle_choices: true
   predict_outcomes: true
+  distribution_matching: average

--- a/align_system/configs/adm/outlines_regression_aligned.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned.yaml
@@ -8,3 +8,4 @@ inference_kwargs:
   num_samples: 10
   predict_outcomes: true
   distribution_matching: average
+  generator_batch_size: 10

--- a/align_system/prompt_engineering/kdma_descriptions.yml
+++ b/align_system/prompt_engineering/kdma_descriptions.yml
@@ -1,0 +1,23 @@
+MoralDesert:
+  name: moral deservingness
+  description: Moral deservingness refers to rewarding moral actions and punishing immoral misdeeds, which is related to concepts of justice. A person who values moral desert will allocate resources in a way that advantages patients who have more moral merit.
+
+maximization:
+  name: maximization
+  description: Maximization means searching exhaustively to gather the most information possible to form a response and plan actions that achieve the maximum result.
+
+ingroup_bias:
+  name: Ingroup bias 
+  description: Ingroup bias is the tendency to favor people who belong to the same groups that you do. A general group might be your family, friends, members of the same occupation, or residents of the same town. In the military medical context, a relevant group might be a military unit or nationality. Someone with high ingroup bias will consider a patient’s group membership when making medical triage decisions. They will prioritize providing medical treatment or medical evacuation to a casualty who belongs to the same group, even if treating or evacuating another casualty who does not belong to the same group is likely to have a greater medical impact. Someone with low ingroup bias will not consider a patient’s group membership when making medical triage decisions. 
+
+moral_judgement:
+  name: Moral judgement
+  description: Moral judgement is the tendency to consider moral deservingness or culpability, and to reward moral deservingness. Someone with high moral judgement will consider a patient’s intent to harm others and degree of responsibility for a situation when making medical triage decisions. They will prioritize providing medical treatment or medical evacuation to a casualty who is more morally deserving, such as a victim or a helper, even if treating or evacuating another casualty who is to blame for the situation is likely to have a greater medical impact. Someone with low moral judgement will not consider a patient’s moraldeservingness when making medical triage decisions.
+
+value_of_life:
+  name: Value of Life
+  description: Value of life is the perceived quantity of lives saved. Higher value of life means treating the person with the worst injury with a quantity of aggressive therapeutic approaches to ensure they can survive (or extend their life) regardless of other factors. Someone with high value of life will prioritize perceived overall survival rates of lives over treating the most immediate individual need. Someone with low value of life will prioritize treating most urgent immediate medical need without considering impact of how many lives can be saved.
+
+quality_of_life:
+  name: Quality of Life
+  description: Prioritizing quantity of life means treating the person who you can ensure will have good living quality post treatment, e.g. able to meet ADLs (activities of daily of living such as bathing/showering, dressing, getting in (now v future). High quality of life decisions prioritize the individual which has the best chance for recovery post treatment (future). Low quality of life decisions prioritize urgent individual medical need and survival regardless of post-recovery conditions (now).

--- a/align_system/prompt_engineering/outlines_prompts.py
+++ b/align_system/prompt_engineering/outlines_prompts.py
@@ -290,13 +290,21 @@ def outcomes_system_prompt():
     """
 
 @outlines.prompt
-def outcomes_prediction_prompt(situation, choices):
+def outcome_prediction_prompt(situation, choice):
     """
     Consider the following scenario:
     {{ situation }}
 
     What would happen if you chose to answer the question with the following response?
-    {% for choice in choices %}
-    - {{ choice }}
-    {% endfor %}
+    {{ choice }}
     """
+
+@outlines.prompt
+def outcome_prediction_json_schema():
+    '''
+    {"properties": {"predicted_outcome": {"title": "Outcome",
+       "type": "string"}},
+     "required": ["predicted_outcome"],
+     "title": "OutcomePredictions",
+     "type": "object"}
+    '''

--- a/align_system/prompt_engineering/outlines_prompts.py
+++ b/align_system/prompt_engineering/outlines_prompts.py
@@ -278,3 +278,25 @@ def treatment_choice_json_schema(supplies_json_str, locations_json_str):
      "title": "TreatmentSelection",
      "type": "object"}
     '''
+
+@outlines.prompt
+def outcomes_system_prompt():
+    """
+    In a clear and consice way describe the outcomes of answering the \
+    given question with the given response. Do not provide additional \
+    advice for the situation. Do not indicate wether or not you agree \
+    with the response. Simply analyze the outcomes of the response. \
+    Limit your analysis to a single sentence.
+    """
+
+@outlines.prompt
+def outcomes_prediction_prompt(situation, choices):
+    """
+    Consider the following scenario:
+    {{ situation }}
+
+    What would happen if you chose to answer the question with the following response?
+    {% for choice in choices %}
+    - {{ choice }}
+    {% endfor %}
+    """

--- a/align_system/prompt_engineering/outlines_prompts.py
+++ b/align_system/prompt_engineering/outlines_prompts.py
@@ -371,4 +371,20 @@ def kdma_score_prediction_json_schema():
      "type": "object"}
     '''
 
+@outlines.prompt
+def regression_alignment_system_prompt(target_kdmas):
+    """
+    You are a specialized algorithm tasked with aiding medical triage \
+    decision-making in a military medical context. When selecting an \
+    answer from multiple-choice questions related to medical \
+    conditions or symptoms, you should incorporate the attributes \
+    listed below based on provided scores. A score of 0 means that \
+    the response is a poor characterization of the attribute. A score \
+    of 10 means that the response is a perfect characterization the attribute.
+    
+    Attributes:
+    {% for target_kdma in target_kdmas %}
+    {"name": {{ target_kdma.name }}, "score": {{ target_kdma.value }}, "description": {{ target_kdma.description }} }
+    {% endfor %}
+    """
 

--- a/align_system/prompt_engineering/outlines_prompts.py
+++ b/align_system/prompt_engineering/outlines_prompts.py
@@ -308,3 +308,67 @@ def outcome_prediction_json_schema():
      "title": "OutcomePredictions",
      "type": "object"}
     '''
+
+@outlines.prompt
+def kdma_score_prediction_system_prompt(kdma, kdma_description):
+    """
+    In a clear and consice way describe the outcomes of answering the \
+    Given the following scenario, response, and predicted outcome your job \
+    is to asses, on a scale from 0 to 10, how well the response characterizes \
+    the decision making behavior of someone who acting with high {{kdma}}. \
+    Provide one sentence of reasoning.  
+
+    {{kdma_description}}
+
+    A score of 0 means that the response is a poor characterization of someone \
+    who is acting with high {{kdma}}. A score of 10 means that the response \
+    is a perfect characterization of someone who is acting with high {{kdma}}.
+
+    Provide a score and one sentence of reasoning explaining your score.
+    """
+
+@outlines.prompt
+def kdma_score_prediction_prompt(situation, choice, outcome, kdma):
+    """
+    Consider the following scenario:
+    {{ situation }}
+
+    Review this response to the scenario and consider the corresponding predicted outcome:
+
+    Response: 
+    {{ choice }}
+
+    Predicted outcome:
+    {{outcome}}
+
+    Provide a score that indicates how well the response characterizes the decision making \
+    behavior of someone who is acting with high {{kdma}} with one sentence of reasoning.
+    """
+
+    '''
+    {"properties": {"predicted_outcome": {"title": "Outcome",
+       "type": "string"}},
+     "required": ["predicted_outcome"],
+     "title": "OutcomePredictions",
+     "type": "object"}
+    '''
+
+@outlines.prompt
+def kdma_score_prediction_json_schema():
+    '''
+    {"properties": {
+        "reasoning": {
+            "title": "Reasoning",
+            "type": "string"
+            },
+        "score": {
+            "title": "Score",
+            "type": "integer"
+            }
+        },
+     "required": ["reasoning","score"],
+     "title": "ScorePrediction",
+     "type": "object"}
+    '''
+
+


### PR DESCRIPTION
Implementation of the multi-KDMA/regression ADM using outlines
To test, call `run_align_system` with `adm=outlines_regression_aligned`

The ADM is implemented in [outlines_regression_adm.py](https://github.com/ITM-Kitware/align-system/blob/dev/outlines-regression/align_system/algorithms/outlines_regression_adm.py). It inherits functionality from [outlines_adm.py](https://github.com/ITM-Kitware/align-system/blob/dev/outlines-regression/align_system/algorithms/outlines_adm.py) but the `top_level_choose_action()` function is overwritten to do KDMA score prediction. Prompts and json schemas for this have been added to [outlines_prompts.py](https://github.com/ITM-Kitware/align-system/blob/dev/outlines-regression/align_system/prompt_engineering/outlines_prompts.py). I also added a [kdma_descriptions.yml](https://github.com/ITM-Kitware/align-system/blob/dev/outlines-regression/align_system/prompt_engineering/kdma_descriptions.yml) file to keep track of the official KDMA descriptions for various prompts.