### PR TITLE
Dev/filter voting to positives; Version 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This changelog follows the specifications detailed in: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), although we have not yet reached a `1.0.0` release.
 
-## Unreleased
+## 0.4.1
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Added dedicated function to utils for calculating votes (same voting scheme as the single KDMA ADM)
 * Added top level config options to force determinism and fix seeds; along with an example experiment to demonstrate
 * Added sampler parameter to outlines ADMs (example usage in `align_system/configs/experiment/examples/outlines_sampler.yaml`)
+* Added option (on by default) to outlines ADM to filter votes to positive options only, can disable on the command line with `+adm.inference_kwargs.filter_votes_to_positives=False`
 
 ### Deprecated 
 * The algorithm `align_system/algorithms/chat_kdma_predicting_adm.py` has been replaced by `align_system/algorithms/outlines_regression_adm.py`

--- a/align_system/utils/voting.py
+++ b/align_system/utils/voting.py
@@ -33,3 +33,14 @@ def calculate_votes(possible_choices,
                         for choice, score in tmp_normalized_votes.items()}
 
     return normalized_votes
+
+
+def filter_votes_to_responses(votes, responses):
+    filtered_votes = {choice: score for choice, score in votes.items()
+                      if choice in responses}
+
+    if len(filtered_votes) == 0:
+        raise RuntimeError(
+            "No votes left after filtering, was `reponses` empty?")
+
+    return filtered_votes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "align-system"
-version = "0.3.3"
+version = "0.4.1"
 description = ""
 authors = ["David Joy <10147749+dmjoy@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
FYSA @eveenhuis @jadie1 here's the voting issue mitigation (stopping short of calling it a fix since there are still cases where things could fail, i.e. if there are no positive responses requested).

For the Outlines ADM this behavior is on by default now, can disable it from the command line with `+adm.inference_kwargs.filter_votes_to_positives=False`

Or in an experiment file with:
```
adm:
    inference_kwargs:
        filter_votes_to_positives: false
```