### PR TITLE
Adding sampling approach to oracle for KDE target

### DIFF
--- a/align_system/algorithms/oracle_adm.py
+++ b/align_system/algorithms/oracle_adm.py
@@ -104,7 +104,7 @@ class OracleADM(ActionBasedADM):
                 scalar_target_kdma_assoc[target['kdma']] = target['value']
 
         # If scalar targets
-        if scalar_target_kdma_assoc:
+        if len(scalar_target_kdma_association) > 0:
             action_to_take = self.match_to_scalar_target(alignment_target, available_actions)
 
         # If KDE targets

--- a/align_system/algorithms/oracle_adm.py
+++ b/align_system/algorithms/oracle_adm.py
@@ -104,7 +104,7 @@ class OracleADM(ActionBasedADM):
                 scalar_target_kdma_assoc[target['kdma']] = target['value']
 
         # If scalar targets
-        if len(scalar_target_kdma_association) > 0:
+        if len(scalar_target_kdma_assoc) > 0:
             action_to_take = self.match_to_scalar_target(alignment_target, available_actions)
 
         # If KDE targets

--- a/align_system/configs/adm/oracle.yaml
+++ b/align_system/configs/adm/oracle.yaml
@@ -3,3 +3,5 @@ instance:
 
   probabilistic: false
   upweight_missing_kdmas: false
+  distribution_matching: sample
+  kde_norm: globalnorm

--- a/align_system/utils/distribution_matching_utils.py
+++ b/align_system/utils/distribution_matching_utils.py
@@ -1,0 +1,22 @@
+from align_system.utils import kde_utils
+
+
+def match_to_target_kde_sample(alignment_target, available_actions, kde_norm):
+	'''
+	Samples a random value from the target KDE and selects the action with KDMA value closest to the sample
+	'''
+	target_kdma = alignment_target.kdma_values[0] # TODO extend this to multi-KDMAs
+	target_kde = kde_utils.load_kde(target_kdma, kde_norm)
+	sampled_target = target_kde.sample(1)[0]
+	
+	selected_action = None
+	min_dist = float('inf')
+	for action in available_actions:
+		if action.kdma_association is not None:
+			choice_value = action.kdma_association[target_kdma['kdma']]
+			dist = abs(sampled_target-choice_value)
+			if dist < min_dist:
+				min_dist = dist 
+				selected_action = action
+
+	return selected_action


### PR DESCRIPTION
This adds the option for oracle alignment to KDE targets by randomly sampling a scalar target from the KDE.
Currently implemented options: 
- `distribution_matching`: `sample`
- `kde_norm`: `globalnorm`, `localnorm`, or `rawscores` (no functionality for `globalnormx_localnormy` yet)
The plan is to be able to add `distribution_matching` options to find the best approach.

@eveenhuis let me know if you have code improvement suggestions
@brianhhu this is a starting point for the idea you shared yesterday 