### PR TITLE
Add leave one out option for comparative regression ADM

### DIFF
--- a/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
@@ -6,6 +6,7 @@ inference_kwargs:
   incontext:
     number: 5
     method: bert_similarity
+    leave_one_out: false
     datasets:
       MoralDesert: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_adept_high-1715105775-input-output.json
       maximization: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_soartech_high-1716581856-input-output.json


### PR DESCRIPTION
Adds leave one out option for comparative regression ADM (conditioning only on scenario description) as a means to limit the effect of testing on training data