### PR TITLE
KDE Alignment Functionality

### DIFF
--- a/align_system/algorithms/outlines_regression_adm.py
+++ b/align_system/algorithms/outlines_regression_adm.py
@@ -27,7 +27,7 @@ from align_system.prompt_engineering.outlines_prompts import (
     kdma_score_prediction_system_prompt_with_examples,
     kdma_score_prediction_prompt,
     kdma_score_prediction_json_schema,
-    regression_alignment_system_prompt,
+    baseline_system_prompt,
     action_selection_prompt
 )
 
@@ -473,7 +473,7 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
         action_to_take.justification = first_justification
 
         # Set up simple diaolg to return for follow-ups
-        alignment_system_prompt = regression_alignment_system_prompt(target_kdmas)
+        alignment_system_prompt = baseline_system_prompt()
         prompt = action_selection_prompt(scenario_description, choices)
         dialog = [{'role': 'system', 'content': alignment_system_prompt},
                   {'role': 'user', 'content': prompt}]

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -503,13 +503,19 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
                     target_kdmas[kdma_idx]['value'] = target_kde.sample(1)
                 selected_choice = self.average_scalar_matching(predicted_kdma_values, target_kdmas)
             elif distribution_matching == 'max_likelihood':
-                # Select choice with max likelihood of predicted scores under target KDE
-                selected_choice = self.mle_distribution_matching(predicted_kdma_values, target_kdmas, kde_norm)
+                if len(target_kdmas) == 1:
+                    # Select choice with max likelihood of predicted scores under target KDE
+                    selected_choice = self.mle_distribution_matching(predicted_kdma_values, target_kdmas, kde_norm)
+                else:
+                    raise RuntimeError(f"{distribution_matching} distribution matching is not implemented for multiple KDMA targets.")
             elif distribution_matching == 'js_divergence':
-                # Convert predicted samples to KDE and compute JS divergence
-                selected_choice = self.kde_js_distribution_matching(predicted_kdma_values, target_kdmas, kde_norm)
+                if len(target_kdmas) == 1:
+                    # Convert predicted samples to KDE and compute JS divergence
+                    selected_choice = self.kde_js_distribution_matching(predicted_kdma_values, target_kdmas, kde_norm)
+                else:
+                    raise RuntimeError(f"{distribution_matching} distribution matching is not implemented for multiple KDMA targets.")
             else:
-                raise RuntimeError(distribution_matching, "distribution matching function unrecognized.")
+                raise RuntimeError(f"{distribution_matching} distribution matching function unrecognized.")
         else:
             raise RuntimeError("Alignment target does not have an associated value or KDEs.")
 

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -31,7 +31,7 @@ from align_system.prompt_engineering.outlines_prompts import (
     comparative_kdma_score_prediction_system_prompt_with_examples,
     comparative_kdma_score_prediction_prompt,
     comparative_kdma_score_prediction_json_schema,
-    regression_alignment_system_prompt,
+    baseline_system_prompt,
     action_selection_prompt
 )
 
@@ -459,7 +459,7 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
 
         # If we have a scalar value target, use average distribution matching
         # TODO extend logic to multi-KDMA scenario with mix of KDE and scalar targets
-        if target_kdmas[0].value is not None:
+        if hasattr(target_kdmas[0], 'value') and target_kdmas[0].value is not None:
             # Averages over predicted score samples and selects choice with minimum MSE to target
             selected_choice = self.average_scalar_matching(predicted_kdma_values, target_kdmas)
             # Currently returning the reasoning associated with the first sample for the selected choice
@@ -489,7 +489,7 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
         action_to_take.justification = self.get_selected_choice_reasoning(selected_choice, predicted_kdma_values, target_kdmas)
 
         # Set up simple diaolg to return for follow-ups
-        alignment_system_prompt = regression_alignment_system_prompt(target_kdmas)
+        alignment_system_prompt = baseline_system_prompt()
         prompt = action_selection_prompt(scenario_description, choices)
         dialog = [{'role': 'system', 'content': alignment_system_prompt},
                   {'role': 'user', 'content': prompt}]

--- a/align_system/configs/adm/oracle.yaml
+++ b/align_system/configs/adm/oracle.yaml
@@ -5,5 +5,8 @@ instance:
   upweight_missing_kdmas: false
   filter_unlabeled_actions: false
   misaligned: false
+
+inference_kwargs:
   distribution_matching: sample
-  kde_norm: globalnorm
+  num_samples: 1
+  kde_norm: rawscores

--- a/align_system/configs/experiment/dry_run_evaluation/random_soartech_qol_train.yaml
+++ b/align_system/configs/experiment/dry_run_evaluation/random_soartech_qol_train.yaml
@@ -8,6 +8,7 @@ interface:
   session_type: soartech
   scenario_ids:
     - qol-dre-1-train
+    - qol-dre-2-train
   training_session: true
 
 align_to_target: true

--- a/align_system/configs/experiment/dry_run_evaluation/random_soartech_vol_train.yaml
+++ b/align_system/configs/experiment/dry_run_evaluation/random_soartech_vol_train.yaml
@@ -8,6 +8,7 @@ interface:
   session_type: soartech
   scenario_ids:
     - vol-dre-1-train
+    - vol-dre-2-train
   training_session: true
 
 align_to_target: true

--- a/align_system/prompt_engineering/outlines_prompts.py
+++ b/align_system/prompt_engineering/outlines_prompts.py
@@ -607,21 +607,3 @@ def comparative_kdma_score_prediction_json_schema(choices):
         "required": list(choices)
     }
     return json.dumps(json_schema)
-
-
-@outlines.prompt
-def regression_alignment_system_prompt(target_kdmas):
-    """
-    You are a specialized algorithm tasked with aiding medical triage \
-    decision-making in a military medical context. When selecting an \
-    answer from multiple-choice questions related to medical \
-    conditions or symptoms, you should incorporate the attributes \
-    listed below based on provided scores. A score of 0 means that \
-    the response is a poor characterization of the attribute. A score \
-    of 10 means that the response is a perfect characterization the attribute.
-
-    Attributes:
-    {% for target_kdma in target_kdmas %}
-    {"name": {{ target_kdma.name }}, "score": {{ target_kdma.value }}, "description": {{ target_kdma.description }} }
-    {% endfor %}
-    """

--- a/align_system/utils/distribution_matching_utils.py
+++ b/align_system/utils/distribution_matching_utils.py
@@ -1,22 +1,46 @@
 from align_system.utils import kde_utils
+import numpy as np
 
-
-def match_to_target_kde_sample(alignment_target, available_actions, kde_norm):
+def match_to_target_kde_sample(alignment_target, available_actions, kde_norm, num_kde_samples=1):
 	'''
-	Samples a random value from the target KDE and selects the action with KDMA value closest to the sample
+	Returns the choice with min average distance to random samples from the target KDE
 	'''
 	target_kdma = alignment_target.kdma_values[0] # TODO extend this to multi-KDMAs
 	target_kde = kde_utils.load_kde(target_kdma, kde_norm)
-	sampled_target = target_kde.sample(1)[0]
+	sampled_targets = target_kde.sample(num_kde_samples)
 	
 	selected_action = None
 	min_dist = float('inf')
 	for action in available_actions:
 		if action.kdma_association is not None:
+			sum_of_dists = 0
 			choice_value = action.kdma_association[target_kdma['kdma']]
-			dist = abs(sampled_target-choice_value)
+			for sampled_target in sampled_targets:
+				sum_of_dists += abs(sampled_target-choice_value)
+			dist = sum_of_dists/num_kde_samples
 			if dist < min_dist:
 				min_dist = dist 
 				selected_action = action
 
+	return selected_action
+
+
+def max_likelihood_matching(alignment_target, available_actions, kde_norm):
+	'''
+	MLE - Returns the choice with the max likelihood under the target KDE
+	'''
+	selected_action = None
+	target_kdma = alignment_target.kdma_values[0] # TODO extend this to multi-KDMAs
+	target_kde = kde_utils.load_kde(target_kdma, kde_norm)
+
+	max_likelihood = 0
+	for action in available_actions:
+		if action.kdma_association is not None:
+			choice_value = action.kdma_association[target_kdma['kdma']]
+			log_likelihood = target_kde.score_samples(np.array([choice_value]).reshape(-1, 1))[0]
+			likelihood = np.exp(log_likelihood)
+			if likelihood > max_likelihood:
+				max_likelihood = log_likelihood
+				selected_action = action
+	
 	return selected_action

--- a/align_system/utils/distribution_matching_utils.py
+++ b/align_system/utils/distribution_matching_utils.py
@@ -40,7 +40,7 @@ def max_likelihood_matching(alignment_target, available_actions, kde_norm):
 			log_likelihood = target_kde.score_samples(np.array([choice_value]).reshape(-1, 1))[0]
 			likelihood = np.exp(log_likelihood)
 			if likelihood > max_likelihood:
-				max_likelihood = log_likelihood
+				max_likelihood = likelihood
 				selected_action = action
 	
 	return selected_action


### PR DESCRIPTION
- Add option to specify `num_kde_samples` for multiple samples in sample-based KDE target alignment for oracle 
- Adds `max-likelihood` KDE target alignment option for oracle and comparative regression ADMs
- Switches regression-based ADMs to use baseline prompt as the starting point for follow-ups. The old regression-specific prompt did not work with KDE targets. Now the baseline and regression-based ADMs have the exact same follow-up procedure 
- Updates the ST training experiments to use both train scenarios