### PR TITLE
Don't allow treatments when supplies aren't available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 * Fixed issue for running in batches with batch size in outlines ADMs
 * Fixed character selection to use the `character_id` associated with the selected action when available, otherwise send a follow up prompt
+* Restrict actions with pre-specified treatments when those supplies are not available
 
 ## 0.4.1
 

--- a/align_system/cli/run_align_system.py
+++ b/align_system/cli/run_align_system.py
@@ -207,6 +207,22 @@ def main(cfg: DictConfig) -> None:
                                   "allowing {} action".format(a.action_type))
                         continue
 
+                if (
+                    a.action_type == ActionTypeEnum.APPLY_TREATMENT and
+                    a.parameters is not None and 'treatment' in a.parameters
+                ):
+                    treatment_available = False
+                    for s in current_state.supplies:
+                        if a.parameters['treatment'] == s.type:
+                            if s.quantity > 0:
+                                treatment_available = True
+                            break
+
+                    if not treatment_available:
+                        log.debug("Insufficient supplies, not allowing "
+                                    f"{ActionTypeEnum.APPLY_TREATMENT} action")
+                        continue
+
                 is_a_noop_action = False
                 for noop_action in noop_actions:
                     if a == noop_action:

--- a/align_system/configs/experiment/dry_run_evaluation/hybrid_kaleido_adept_ingroup_bias_train.yaml
+++ b/align_system/configs/experiment/dry_run_evaluation/hybrid_kaleido_adept_ingroup_bias_train.yaml
@@ -12,6 +12,8 @@ interface:
   session_type: adept
   scenario_ids:
     - DryRunEval.IO1
+    - DryRunEval.IO2
+    - DryRunEval.IO3
   training_session: true
 
 align_to_target: true

--- a/align_system/configs/experiment/dry_run_evaluation/hybrid_kaleido_adept_moral_judgement_train.yaml
+++ b/align_system/configs/experiment/dry_run_evaluation/hybrid_kaleido_adept_moral_judgement_train.yaml
@@ -12,6 +12,7 @@ interface:
   session_type: adept
   scenario_ids:
     - DryRunEval.MJ1
+    - DryRunEval.MJ3
   training_session: true
 
 align_to_target: true

--- a/align_system/configs/experiment/dry_run_evaluation/random_adept_ingroup_bias_train.yaml
+++ b/align_system/configs/experiment/dry_run_evaluation/random_adept_ingroup_bias_train.yaml
@@ -8,6 +8,8 @@ interface:
   session_type: adept
   scenario_ids:
     - DryRunEval.IO1
+    - DryRunEval.IO2
+    - DryRunEval.IO3
   training_session: true
 
 align_to_target: true

--- a/align_system/configs/experiment/dry_run_evaluation/random_adept_moral_judgement_train.yaml
+++ b/align_system/configs/experiment/dry_run_evaluation/random_adept_moral_judgement_train.yaml
@@ -8,6 +8,7 @@ interface:
   session_type: adept
   scenario_ids:
     - DryRunEval.MJ1
+    - DryRunEval.MJ3
   training_session: true
 
 align_to_target: true


### PR DESCRIPTION
Update ADEPT train experiments to include new scenarios. The new scenarios identified the need to restrict pre-specified treatments when supplies are insufficient, so a fix for this is included.
