### PR TITLE
Hybrid Regression Updates

### DIFF
--- a/align_system/algorithms/outlines_hybrid_regression_adm.py
+++ b/align_system/algorithms/outlines_hybrid_regression_adm.py
@@ -99,7 +99,7 @@ class BertRegressionModel:
             output = logits.squeeze().detach().cpu().numpy()
             predictions = np.append(predictions, output)
 
-        return predictions
+        return np.clip(predictions, 0, 1)
 
 
 class HybridRegressionADM(OutlinesTransformersADM):

--- a/align_system/configs/adm/hybrid_regression.yaml
+++ b/align_system/configs/adm/hybrid_regression.yaml
@@ -7,7 +7,7 @@ inference_kwargs:
   models:
     model_name: 'bert-base-uncased'
     target_checkpoint:
-      Moral judgement: /data/shared/model_checkpoints/hybrid_regression/moral_judgement.pt
-      Ingroup Bias: /data/shared/model_checkpoints/hybrid_regression/ingroup_bias.pt
-      PerceivedQuantityOfLivesSaved: /data/shared/model_checkpoints/hybrid_regression/value_of_life.pt
-      QualityOfLife: /data/shared/model_checkpoints/hybrid_regression/quality_of_life.pt
+      Moral judgement: /data/shared/model_checkpoints/hybrid_regression/v2/moral_judgement.pt
+      Ingroup Bias: /data/shared/model_checkpoints/hybrid_regression/v2/ingroup_bias.pt
+      PerceivedQuantityOfLivesSaved: /data/shared/model_checkpoints/hybrid_regression/v2.2/value_of_life.pt
+      QualityOfLife: /data/shared/model_checkpoints/hybrid_regression/v2.2/quality_of_life.pt


### PR DESCRIPTION
@dmjoy @eveenhuis 

This PR makes the following updates:
(1) Bugfix: Clip the regression model predictions to be between 0 and 1.
(2) Update `hybrid_regression.yaml` hydra config file to include the paths to the latest model weights.