### PR TITLE
WIP initial support for "multi-adm" configs

### DIFF
--- a/align_system/configs/experiment/dry_run_evaluation/multi_adm_test_eval.yaml
+++ b/align_system/configs/experiment/dry_run_evaluation/multi_adm_test_eval.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+defaults:
+  - /adm@adm1: random
+  - /adm@adm2: outlines_transformers_structured_baseline
+  - override /interface: ta3
+
+interface:
+  api_endpoint: "http://127.0.0.1:8089"
+  session_type: eval
+  training_session: false
+  username: "ALIGN-ADM-Random-Multi-Baseline"
+
+align_to_target: true
+save_last_unstructured_state_per_scenario: true
+
+adm2:
+  instance:
+    precision: half
+
+adm_mappings:
+  - scenario_pattern: '^qol.*'
+    alignment_target_pattern: '^qol.*'
+    adm: ${adm2}
+  - scenario_pattern: '.*'
+    alignment_target_pattern: '.*'
+    adm: ${adm1}
+
+hydra:
+  run:
+    dir: 'random_eval_live/${now:%Y-%m-%d__%H-%M-%S}'

--- a/align_system/configs/multi_adm.yaml
+++ b/align_system/configs/multi_adm.yaml
@@ -1,0 +1,23 @@
+name: multi_adm
+
+defaults:
+  - _self_
+  - interface: ta3
+  - adm@adm1: random
+  - override hydra/job_logging: custom
+
+loglevel: "EXPLAIN"
+
+save_log: true
+save_input_output: true
+save_scoring_output: true
+save_alignment_targets: false
+save_timing: true
+save_last_unstructured_state_per_scenario: true
+
+align_to_target: true
+
+adm_mappings:
+  - scenario_pattern: '.*'
+    alignment_target_pattern: '.*'
+    adm: ${adm1}


### PR DESCRIPTION
** DO NOT MERGE AS IS **

(Probably needs more thought / discussion about how best to implement this; but it's something that mostly works as is)

Need to specify `--config-name multi_adm` prior to any experiment or overrides with the `run_align_system` command.

FYSA @eveenhuis 