### PR TITLE
Clamp KDE target samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 * Fixed issue in Oracle ADM which caused an key error exception when logging probabilities
+* Fixed KDE target samples to be between 0 and 1
 
 ## 0.5.1
 

--- a/align_system/utils/alignment_utils.py
+++ b/align_system/utils/alignment_utils.py
@@ -132,7 +132,9 @@ class MinDistToRandomSampleKdeAlignment(AlignmentFunction):
 
             sampled_target_kdma = {'kdma':target_kdma["kdma"]}
             target_kde = kde_utils.load_kde(target_kdma, kde_norm)
-            sampled_target_kdma['value']= float(target_kde.sample(1)) # sample returns array
+            kde_sample = float(target_kde.sample(1)) # sample returns array
+            kde_sample = max(0.0, min(kde_sample, 1.0)) # clamp to be between 0 and 1
+            sampled_target_kdma['value'] = kde_sample
             log.info("Sampled Target KDMA Value(s): {}".format(sampled_target_kdma['value']))
 
             # Log average KDMA values for each KDMA/choice; this


### PR DESCRIPTION
This is a tiny PR that just ensures the values sampled from target KDEs are between 0 and 1