### PR TITLE
ICL Reformat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,23 +3,31 @@
 This changelog follows the specifications detailed in: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), although we have not yet reached a `1.0.0` release.
 
-## 0.5.2
+## Unreleased
 
 ### Changed
 
 * Moved incontext learning functionality into `incontext_utils.py` and updated the base outlines and comparative regession ADMS to use this module.
-* Moved the `format_choices()` function from the `OutlinesTransformersADM` class in `outlines_adm.py` to a new utils file: `adm_utils.py` so it can be used across ADMs. 
+* Moved the `format_choices()` function from the `OutlinesTransformersADM` class in `outlines_adm.py` to a new utils file: `adm_utils.py` so it can be used across ADMs.
 
 ### Added
 
 * Added option to normalize KDMA values in incontext examples
+  
+### Fixed
+
+* Fixed KDE target samples to be between 0 and 1
+  
+## 0.5.2
+
+### Added
+
 * Split out our experiment configuration for our aligned DRE ADM to specific configs for SoarTech and Adept
 * Added logging for sampled KDMA target value, and estimated KDMA values in alignment_utils
 
 ### Fixed
 
 * Fixed issue in Oracle ADM which caused an key error exception when logging probabilities
-* Fixed KDE target samples to be between 0 and 1
 
 ## 0.5.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 0.5.2
 
+### Changed
+
+* Moved incontext learning functionality into `incontext_utils.py` and updated the base outlines and comparative regession ADMS to use this module.
+* Moved the `format_choices()` function from the `OutlinesTransformersADM` class in `outlines_adm.py` to a new utils file: `adm_utils.py` so it can be used across ADMs. 
+
 ### Added
 
+* Added option to normalize KDMA values in incontext examples
 * Split out our experiment configuration for our aligned DRE ADM to specific configs for SoarTech and Adept
 * Added logging for sampled KDMA target value, and estimated KDMA values in alignment_utils
 

--- a/align_system/algorithms/kaleido_adm.py
+++ b/align_system/algorithms/kaleido_adm.py
@@ -319,8 +319,8 @@ class KaleidoADM(AlignedDecisionMaker, ActionBasedADM):
         choices_unstructured = adm_utils.format_choices(
             choices_unstructured,
             available_actions,
-            scenario_state,
-            log)
+            scenario_state
+            )
 
         target_kdmas = alignment_target.kdma_values
 

--- a/align_system/algorithms/kaleido_adm.py
+++ b/align_system/algorithms/kaleido_adm.py
@@ -14,6 +14,7 @@ from align_system.algorithms.abstracts import AlignedDecisionMaker
 from align_system.algorithms.lib.util import format_template
 from align_system.algorithms.outlines_adm import OutlinesTransformersADM
 from align_system.utils import logging
+from align_system.utils import adm_utils
 from align_system.utils import alignment_utils
 
 
@@ -315,10 +316,11 @@ class KaleidoADM(AlignedDecisionMaker, ActionBasedADM):
         # this function out to utilities somewhere as it's generally
         # useful
         choices_unstructured = [a.unstructured for a in available_actions]
-        choices_unstructured = OutlinesTransformersADM.format_choices(
+        choices_unstructured = adm_utils.format_choices(
             choices_unstructured,
             available_actions,
-            scenario_state)
+            scenario_state,
+            log)
 
         target_kdmas = alignment_target.kdma_values
 

--- a/align_system/algorithms/outlines_adm.py
+++ b/align_system/algorithms/outlines_adm.py
@@ -126,8 +126,7 @@ class OutlinesTransformersADM(ActionBasedADM):
         choices = adm_utils.format_choices(
             [a.unstructured for a in actions],
             actions,
-            scenario_state,
-            log
+            scenario_state
         )
 
         scenario_description = scenario_state_description_1(scenario_state)
@@ -219,9 +218,8 @@ class OutlinesTransformersADM(ActionBasedADM):
         choices = adm_utils.format_choices(
             [a.unstructured for a in available_actions],
             available_actions,
-            scenario_state,
-            log
-        )
+            scenario_state
+            )
 
         positive_icl_examples = []
         negative_icl_examples = []

--- a/align_system/algorithms/outlines_hybrid_regression_adm.py
+++ b/align_system/algorithms/outlines_hybrid_regression_adm.py
@@ -9,7 +9,7 @@ from transformers import AutoModelForSequenceClassification, AutoConfig, AutoTok
 
 from rich.highlighter import JSONHighlighter
 
-from align_system.utils import logging, alignment_utils
+from align_system.utils import logging, alignment_utils, adm_utils
 from align_system.algorithms.outlines_adm import OutlinesTransformersADM
 from align_system.prompt_engineering.outlines_prompts import (
     action_selection_prompt,
@@ -119,10 +119,11 @@ class HybridRegressionADM(OutlinesTransformersADM):
         # Important that the choices stay in the same order as the
         # available actions as we'll use the selected index later to
         # map to the corresponding action
-        choices = self.format_choices(
+        choices = adm_utils.format_choices(
             [a.unstructured for a in available_actions],
             available_actions,
-            scenario_state
+            scenario_state,
+            log
         )
 
         data_dict = {

--- a/align_system/algorithms/outlines_hybrid_regression_adm.py
+++ b/align_system/algorithms/outlines_hybrid_regression_adm.py
@@ -122,8 +122,7 @@ class HybridRegressionADM(OutlinesTransformersADM):
         choices = adm_utils.format_choices(
             [a.unstructured for a in available_actions],
             available_actions,
-            scenario_state,
-            log
+            scenario_state
         )
 
         data_dict = {

--- a/align_system/algorithms/outlines_regression_adm.py
+++ b/align_system/algorithms/outlines_regression_adm.py
@@ -235,8 +235,7 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
                 icl_choices = adm_utils.format_choices(
                     [a.unstructured for a in actions],
                     actions,
-                    state,
-                    log
+                    state
                 )
                 for action, icl_choice, label in zip(actions, icl_choices, icl_sample["label"]):
                     if dset_kdma not in label:
@@ -448,8 +447,7 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
         choices = adm_utils.format_choices(
             [a.unstructured for a in available_actions],
             available_actions,
-            scenario_state,
-            log
+            scenario_state
         )
 
         target_kdmas = alignment_target.kdma_values

--- a/align_system/algorithms/outlines_regression_adm.py
+++ b/align_system/algorithms/outlines_regression_adm.py
@@ -15,6 +15,7 @@ from swagger_client.models import (
 )
 
 from align_system.utils import logging
+from align_system.utils import adm_utils
 from align_system.utils.hydrate_state import hydrate_scenario_state
 from align_system.algorithms.outlines_adm import OutlinesTransformersADM
 from align_system.prompt_engineering.outlines_prompts import (
@@ -231,10 +232,11 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
             icl_datasets[dset_kdma] = []
             for icl_sample in dset:
                 state, actions = hydrate_scenario_state(icl_sample["input"])
-                icl_choices = self.format_choices(
+                icl_choices = adm_utils.format_choices(
                     [a.unstructured for a in actions],
                     actions,
-                    state
+                    state,
+                    log
                 )
                 for action, icl_choice, label in zip(actions, icl_choices, icl_sample["label"]):
                     if dset_kdma not in label:
@@ -443,10 +445,11 @@ class OutlinesTransformersRegressionADM(OutlinesTransformersADM):
         # Important that the choices stay in the same order as the
         # available actions as we'll use the selected index later to
         # map to the corresponding action
-        choices = self.format_choices(
+        choices = adm_utils.format_choices(
             [a.unstructured for a in available_actions],
             available_actions,
-            scenario_state
+            scenario_state,
+            log
         )
 
         target_kdmas = alignment_target.kdma_values

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -10,6 +10,7 @@ from rich.highlighter import JSONHighlighter
 from swagger_client.models import kdma_value
 
 from align_system.utils import logging
+from align_system.utils import adm_utils
 from align_system.utils import outlines_prompts_utils
 from align_system.utils import alignment_utils
 from align_system.utils.hydrate_state import hydrate_scenario_state
@@ -122,10 +123,11 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
             icl_datasets[dset_kdma] = []
             for icl_sample in dset:
                 state, actions = hydrate_scenario_state(icl_sample["input"])
-                icl_choices = self.format_choices(
+                icl_choices = adm_utils.format_choices(
                     [a.unstructured for a in actions],
                     actions,
-                    state
+                    state,
+                    log
                 )
 
                 icl_choices_with_outcomes = {}
@@ -327,10 +329,11 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
         # Important that the choices stay in the same order as the
         # available actions as we'll use the selected index later to
         # map to the corresponding action
-        choices = self.format_choices(
+        choices = adm_utils.format_choices(
             [a.unstructured for a in available_actions],
             available_actions,
-            scenario_state
+            scenario_state,
+            log
         )
 
         target_kdmas = alignment_target.kdma_values

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -129,8 +129,7 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
         if "number" in incontext_settings and incontext_settings["number"] > 0:
             use_icl = True
             icl_example_generator = incontext_utils.ComparativeRegressionIncontextExampleGenerator(incontext_settings,
-                                                                                                   target_kdmas,
-                                                                                                   log)
+                                                                                                   target_kdmas)
 
         kdma_dialogs = []
         # loop over samples
@@ -142,7 +141,8 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
                                                                                                           target_kdma['description'],
                                                                                                           target_kdma['score_examples'])
                 else:
-                    kdma_score_sys_prompt = comparative_kdma_score_prediction_system_prompt(target_kdma['name'], target_kdma['description'])
+                    kdma_score_sys_prompt = comparative_kdma_score_prediction_system_prompt(target_kdma['name'],
+                                                                                            target_kdma['description'])
 
                 icl_examples = []
                 if use_icl:
@@ -251,8 +251,7 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
         choices = adm_utils.format_choices(
             [a.unstructured for a in available_actions],
             available_actions,
-            scenario_state,
-            log
+            scenario_state
         )
 
         target_kdmas = alignment_target.kdma_values

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -146,10 +146,15 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
 
                 icl_examples = []
                 if use_icl:
-                    selected_icl_examples = icl_example_generator.select_icl_examples(target_kdma['kdma'],
-                                                                                      target_kdma['name'],
-                                                                                      scenario_description,
-                                                                                      choices)
+                    # Exclude outcome prediction in prompt_to_match because ICL examples don't have outcomes
+                    no_outcome_predictions = {}
+                    for choice in choices:
+                        no_outcome_predictions[choice] = {}
+                        no_outcome_predictions[choice]['predicted_outcome'] = None
+                    prompt_to_match = comparative_kdma_score_prediction_prompt(scenario_description,
+                                                                                    no_outcome_predictions,
+                                                                                    target_kdma['name'])
+                    selected_icl_examples = icl_example_generator.select_icl_examples(target_kdma['kdma'], prompt_to_match)
                     for icl_sample in selected_icl_examples:
                         icl_examples.extend([
                             {"role": "user", "content": icl_sample['prompt']},

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -154,7 +154,9 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
                     prompt_to_match = comparative_kdma_score_prediction_prompt(scenario_description,
                                                                                     no_outcome_predictions,
                                                                                     target_kdma['name'])
-                    selected_icl_examples = icl_example_generator.select_icl_examples(target_kdma['kdma'], prompt_to_match)
+                    selected_icl_examples = icl_example_generator.select_icl_examples(target_kdma['kdma'],
+                                                                                      scenario_description, 
+                                                                                      prompt_to_match)
                     for icl_sample in selected_icl_examples:
                         icl_examples.extend([
                             {"role": "user", "content": icl_sample['prompt']},

--- a/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
@@ -5,7 +5,7 @@ inference_kwargs:
   generator_batch_size: 5
   incontext:
     number: 5
-    method: bert_similarity
+    method: prompt_bert_similarity
     leave_one_out: false
     datasets:
       MoralDesert: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_adept_high-1715105775-input-output.json

--- a/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
@@ -7,6 +7,7 @@ inference_kwargs:
     number: 5
     method: prompt_bert_similarity
     leave_one_out: false
+    normalization: globalnorm
     datasets:
       MoralDesert: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_adept_high-1715105775-input-output.json
       maximization: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_soartech_high-1716581856-input-output.json

--- a/align_system/configs/adm/outlines_transformers_structured_aligned/incontext.yaml
+++ b/align_system/configs/adm/outlines_transformers_structured_aligned/incontext.yaml
@@ -4,7 +4,11 @@ defaults:
 inference_kwargs:
   incontext:
     number: 5
-    method: bert_similarity
+    method: scenario_bert_similarity
     datasets:
       MoralDesert: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_adept_high-1715105775-input-output.json
       maximization: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_soartech_high-1716581856-input-output.json
+      Moral judgement: /data/shared/samba/dry_run/moral_judgement_20240826.json
+      Ingroup Bias: /data/shared/samba/dry_run/ingroup_bias_20240826.json
+      QualityOfLife: /data/shared/samba/dry_run/qol_20240826.json
+      PerceivedQuantityOfLivesSaved: /data/shared/samba/dry_run/vol_20240826.json

--- a/align_system/utils/adm_utils.py
+++ b/align_system/utils/adm_utils.py
@@ -1,0 +1,34 @@
+from swagger_client.models import (
+    ActionTypeEnum
+)
+from align_system.prompt_engineering.outlines_prompts import (
+    detailed_unstructured_treatment_action_text,
+    detailed_unstructured_tagging_action_text
+)
+
+def format_choices(choices, available_actions, scenario_state, log):
+    """
+    If choices are not unique, format choices to include state information.
+    """
+    if len(set(choices)) != len(choices):
+        log.warning("Unstructured text for available actions is not "
+                    "unique, appending action parameters to choices")
+
+        character_id_to_name = {c.id: c.name for c in scenario_state.characters}
+        # Important that the choices stay in the same order as the
+        # available actions as we'll use the selected index later to
+        # map to the corresponding action
+        choices = []
+        for a in available_actions:
+            if(a.action_type == ActionTypeEnum.APPLY_TREATMENT
+                and a.parameters is not None and len(a.parameters) > 0):
+                choices.append(detailed_unstructured_treatment_action_text(a, character_id_to_name))
+            elif(a.action_type == ActionTypeEnum.TAG_CHARACTER
+                    and a.parameters is not None and len(a.parameters) > 0):
+                choices.append(detailed_unstructured_tagging_action_text(a, character_id_to_name))
+            else:
+                # Not covering every possible case here, may need
+                # to add more dedicated detailed prompts
+                choices.append(a.unstructured)
+
+    return choices

--- a/align_system/utils/adm_utils.py
+++ b/align_system/utils/adm_utils.py
@@ -5,8 +5,11 @@ from align_system.prompt_engineering.outlines_prompts import (
     detailed_unstructured_treatment_action_text,
     detailed_unstructured_tagging_action_text
 )
+from align_system.utils import logging
 
-def format_choices(choices, available_actions, scenario_state, log):
+log = logging.getLogger(__name__)
+
+def format_choices(choices, available_actions, scenario_state):
     """
     If choices are not unique, format choices to include state information.
     """

--- a/align_system/utils/incontext_utils.py
+++ b/align_system/utils/incontext_utils.py
@@ -136,14 +136,6 @@ class IncontextExampleGenerator(object, metaclass=ABCMeta):
 
 
 class ComparativeRegressionIncontextExampleGenerator(IncontextExampleGenerator):
-    def __init__(self,
-                 incontext_settings, 
-                 target_kdmas, 
-                 **kwargs):
-        self.incontext_settings = incontext_settings
-        self.target_kdmas = target_kdmas
-        self.set_icl_datasets()
-    
     def set_icl_datasets(self):
         icl_datasets = {}
         incontext_data = self._read_icl_dataset_files()

--- a/align_system/utils/incontext_utils.py
+++ b/align_system/utils/incontext_utils.py
@@ -22,11 +22,9 @@ class IncontextExampleGenerator(object, metaclass=ABCMeta):
     def __init__(self,
                  incontext_settings, 
                  target_kdmas, 
-                 log,
                  **kwargs):
         self.incontext_settings = incontext_settings
         self.target_kdmas = target_kdmas
-        self.log = log
         self.set_icl_datasets()
 
     @abstractmethod
@@ -73,8 +71,7 @@ class IncontextExampleGenerator(object, metaclass=ABCMeta):
                     choices = adm_utils.format_choices(
                         [a.unstructured for a in actions],
                         actions,
-                        state,
-                        self.log
+                        state
                     )
                     # Get KDMA_values
                     kdma_values = []
@@ -140,11 +137,9 @@ class ComparativeRegressionIncontextExampleGenerator(IncontextExampleGenerator):
     def __init__(self,
                  incontext_settings, 
                  target_kdmas, 
-                 log,
                  **kwargs):
         self.incontext_settings = incontext_settings
         self.target_kdmas = target_kdmas
-        self.log = log
         self.set_icl_datasets()
     
     def set_icl_datasets(self):

--- a/align_system/utils/incontext_utils.py
+++ b/align_system/utils/incontext_utils.py
@@ -4,7 +4,6 @@ import random
 from copy import deepcopy
 from abc import ABCMeta, abstractmethod
 
-
 from align_system.utils import adm_utils
 from align_system.utils import outlines_prompts_utils
 from align_system.utils.hydrate_state import hydrate_scenario_state
@@ -17,6 +16,7 @@ from align_system.prompt_engineering.outlines_prompts import (
 class IncontextExampleGenerator(object, metaclass=ABCMeta):
     '''
     Abstract class for incontext example generator
+    Instances of this class have unique set_icl_datasets() functions for formatting prompt and reponses 
     '''
     @abstractmethod
     def __init__(self,
@@ -38,23 +38,16 @@ class IncontextExampleGenerator(object, metaclass=ABCMeta):
 
         The keys of self.icl_datasets are the 'kdma' keys from self.target_kdmas,
         the values are a list of all ICL examples for that kdma,
-        each ICL example is a dictionary with keys: 'scenario_description', 'prompt', 'response'
-        For example: {kdma: [{'scenario_description':str, 'prompt':str, 'response':json}, ...], ...}
+        each ICL example is a dictionary with keys: 'prompt', 'response'
+        For example: {kdma: [{'prompt':str, 'response':json}, ...], ...}
         '''
         self.icl_datasets = {}
         pass
 
-    @abstractmethod
-    def select_icl_examples(self):
-        '''
-        Returns a subset of self.icl_datasets that are relevant examples
-        '''
-        pass
-
     def read_icl_dataset_files(self):
         '''
-        Helper function, reads dataset files and gets examples for target_kdmas
-        Return incontext_data with format:
+        Helper function for set_icl_datasets() - reads dataset files and gets examples for target_kdmas
+        Returns incontext_data dictionary with format:
             {kdma:[{state, actions, choices, kdma_values}, ...], ...}
         '''
         incontext_data = {}
@@ -67,14 +60,14 @@ class IncontextExampleGenerator(object, metaclass=ABCMeta):
             if not isinstance(dset_files, list):
                 dset_files = [dset_files]
             
+            # For each dataset file
             for dset_f in dset_files:
-                # Load dataset file
                 with open(dset_f) as f:
                     dset = json.load(f)
                 incontext_data[sys_kdma_name] = []
                 # Load each example in the dataset file
                 for icl_sample in dset:
-                    # Get state
+                    # Get state and actions
                     state, actions = hydrate_scenario_state(icl_sample["input"])
                     # Get choices
                     choices = adm_utils.format_choices(
@@ -93,9 +86,54 @@ class IncontextExampleGenerator(object, metaclass=ABCMeta):
                     example = {'state':state, 'actions': actions, 'choices':choices, 'kdma_values':kdma_values}
                     incontext_data[sys_kdma_name].append(example)
             
-            # TODO - normalize KDMA values
+            # TODO - add KDMA normalization option
             
             return incontext_data
+
+    def select_icl_examples(self, sys_kdma_name, prompt_to_match):
+        '''
+        Selects a list of relevant ICL examples
+        Input:
+            sys_kdma_name - key of the target kdma in self.icl_datasets
+            prompt_to_match - the prompt we are selecting ICL examples for
+        Output:
+            selected_icl_examples - relevant subset of self.icl_datasets
+        '''
+        # Check that we have incontext examples for the target kdma
+        if sys_kdma_name not in self.icl_datasets:
+            raise RuntimeError(f"No incontext samples for targeted kdma: {sys_kdma_name}")
+        n_icl_examples = self.incontext_settings["number"]
+        possible_icl_examples = self.icl_datasets[sys_kdma_name]
+        # Check that we have enough incontext examples for the target kdma
+        if len(possible_icl_examples) < n_icl_examples:
+            raise RuntimeError(f"Not enough possible incontext samples to learn from. Only "
+                            f"{len(possible_icl_examples)} samples available while asking for "
+                            f"{n_icl_examples} incontext samples.")
+        # If using LOO, don't include example ICL with exact same prompt
+        if self.incontext_settings.get("leave_one_out", False):
+            possible_icl_examples = [
+                icl_ex for icl_ex in possible_icl_examples
+                if icl_ex["prompt"] != prompt_to_match
+            ]
+
+        # Downselect to n_icl_examples via given method
+        icl_strategy = self.incontext_settings["method"]
+        
+        if icl_strategy == "random":
+            selected_icl_examples = random.sample(possible_icl_examples, n_icl_examples)
+        elif icl_strategy == "bert_similarity":
+            possible_icl_prompts = [icl_sample["prompt"] for icl_sample in possible_icl_examples]
+            # Create similarity scores between the ICL samples and find top-k indices
+            from bert_score import score
+            _, _, F1 = score([prompt_to_match]*len(possible_icl_prompts), possible_icl_prompts, lang="en")
+            _, indices = torch.topk(F1, n_icl_examples)
+
+            selected_icl_examples = [possible_icl_examples[i] for i in indices]
+        else:
+            raise ValueError(f'"{icl_strategy}" is not a valid incontext method. Please use "random" or '
+                                '"bert_similarity"')
+
+        return selected_icl_examples
 
 
 class ComparativeRegressionIncontextExampleGenerator(IncontextExampleGenerator):
@@ -121,10 +159,10 @@ class ComparativeRegressionIncontextExampleGenerator(IncontextExampleGenerator):
             
             # Add each examples to icl_datasets
             for example in kdma_incontext_data:
-                # Get example scenario description
+                
+                # Get example prompt
                 character_info = outlines_prompts_utils.get_relevant_structured_character_info(example['state'].characters)
                 icl_scenario_description = scenario_state_description_with_relevant_char_info(example['state'], character_info)
-                # Get example prompt
                 icl_choices_with_outcomes = {}
                 for choice in example['choices']:
                     # TODO: Include outcome prediction for ICL examples?
@@ -133,161 +171,117 @@ class ComparativeRegressionIncontextExampleGenerator(IncontextExampleGenerator):
                                                                     icl_choices_with_outcomes,
                                                                     sys_kdma_name)
                 # Get example response
-                icl_reponse = {}
+                icl_response = {}
                 for action, choice, kdma_value in zip(example['actions'], example['choices'], example["kdma_values"]):
                     # Only include choice if there is a ground truth KDMA value available
                     if kdma_value is None:
                         continue
-                    icl_reponse[choice] = {}
-                    icl_reponse[choice]['reasoning'] = get_chain_of_thought_reasoning(target_kdma, action,
-                                                                                            example['state'], choice,
-                                                                                            kdma_value)
                     # Predicted scores are 0-10, KDMA values are 0-1
-                    icl_reponse[choice]['score'] = int(kdma_value * 10)
-                # Add full example
+                    scaled_kdma_value = int(kdma_value * 10)
+                    icl_response[choice] = {}
+                    icl_response[choice]['reasoning'] = self.get_chain_of_thought_reasoning(target_kdma, action,
+                                                                                            example['state'], choice,
+                                                                                            scaled_kdma_value)
+                    icl_response[choice]['score'] = scaled_kdma_value
+
+                # Add example
                 icl_datasets[sys_kdma_name].append({
-                    "scenario_description": icl_scenario_description,
                     "prompt": icl_prompt,
-                    "response": icl_reponse
+                    "response": icl_response
                     })
                 
         self.icl_datasets = icl_datasets
-    
-    def select_icl_examples(self, sys_kdma_name, print_kdma_name, scenario_description, choices):
-        n_icl_examples = self.incontext_settings["number"]
-        if sys_kdma_name not in self.icl_datasets:
-            raise RuntimeError(f"No incontext samples for targeted kdma: {sys_kdma_name}")
-        possible_icl_examples = self.icl_datasets[sys_kdma_name]
-        if self.incontext_settings.get("leave_one_out", False):
-            # Don't include example ICL with exact same scenario state
-            possible_icl_examples = [
-                icl_ex for icl_ex in possible_icl_examples
-                if icl_ex["scenario_description"] != scenario_description
-            ]
-        if len(possible_icl_examples) < n_icl_examples:
-            raise RuntimeError(f"Not enough possible incontext samples to learn from. Only "
-                            f"{len(possible_icl_examples)} samples available while asking for "
-                            f"{n_icl_examples} incontext samples.")
 
-        # Downselect to n_icl_examples via given method
-        icl_strategy = self.incontext_settings["method"]
-        if icl_strategy == "random":
-            selected_icl_examples = random.sample(possible_icl_examples, n_icl_examples)
-        elif icl_strategy == "bert_similarity":
-            # TODO: Include outcome prediction for ICL examples?
-            no_outcome_predictions = {}
-            for choice in choices:
-                no_outcome_predictions[choice] = {}
-                no_outcome_predictions[choice]['predicted_outcome'] = None
-            no_outcome_prompt = comparative_kdma_score_prediction_prompt(scenario_description,
-                                                                            no_outcome_predictions,
-                                                                            print_kdma_name)
+    def get_chain_of_thought_reasoning(self, target_kdma, action, state, choice, expected_value):
+        '''
+        Helper function for set_icl_datasets() - constructs example reasoning statements for responses
+        '''
+        cot_reasoning = ""
 
-            possible_icl_prompts = [icl_sample["prompt"] for icl_sample in possible_icl_examples]
+        # get character associated with action
+        action_character = None
+        if hasattr(action, 'character_id') and action.character_id is not None:
+            for character in state.characters:
+                if character.id == action.character_id:
+                    action_character = character
+                    break
 
-            # Create similarity scores between the ICL samples and find top-k indices
-            from bert_score import score
-            _, _, F1 = score([no_outcome_prompt]*len(possible_icl_prompts), possible_icl_prompts, lang="en")
-            _, indices = torch.topk(F1, n_icl_examples)
+        # Moral derivngess or moral judgement
+        # Example: Because Alex acted with no intent and did not cause of harm,
+        #          choosing Treat Alex would score a 5 for the the principle of moral judgement.
+        if target_kdma['kdma'] == 'MoralDesert' or  target_kdma['kdma'] == 'Moral judgement':
+            if action_character is not None:
+                # add intent to reasoning
+                if not hasattr(action_character, 'intent') or action_character.intent is None or action_character.intent == 'no intent':
+                    cot_reasoning += f"Because {action_character.name} acted with no intent"
+                else:
+                    cot_reasoning += f"Because {action_character.name} acted to {action_character.intent}"
+                # add directness of causality to reasoning
+                if not hasattr(action_character, 'directness_of_causality') or action_character.directness_of_causality is None or action_character.directness_of_causality == 'none':
+                        cot_reasoning += f" and did not cause of harm"
+                else:
+                    cot_reasoning += f" and had a {action_character.directness_of_causality} cause of harm"
 
-            selected_icl_examples = [possible_icl_examples[i] for i in indices]
+        # Ingroup bias
+        # Example: Patient A is a soldier in your unit and is in group Allied US,
+        #           choosing to treat patient A would score a 6 for ingroup bias.
+        elif target_kdma['kdma'] == 'Ingroup Bias':
+            if action_character is not None:
+                # add unstructured charcter description to reasoning
+                if hasattr(action_character, 'unstructured') and action_character.unstructured is not None:
+                    cot_reasoning += f"Because {action_character.name} is {action_character.unstructured.rstrip()}"
+                    # add military disposition
+                    if action_character.demographics['military_disposition'] is not None:
+                        cot_reasoning += f" and is in group {action_character.demographics['military_disposition']}"
+
+        # Quality of life
+        # Example
+            # Because Casualty X would have better quality of life post-treatment, choosing Treat Casualty X with a tourniquet would score a 9 for the the principle of quality of life.
+            # Because Casualty X would have better quality of life post-treatment but it is not the best treatment approach, choosing Treat Casualty X with hemostatic gauze would score a 7 for the the principle of quality of life.
+            # Because Casualty Y would have worse quality of life post-treatment but the supplies needed to treat the other casualty would still be available, choosing Treat Casualty Y with hemostatic gauze would score a 3 for the the principle of quality of life.
+            # Because Casualty Y would have worse quality of life post-treatment, choosing Treat Casualty Y with a tourniquet would score a 1 for the the principle of quality of life.
+        elif target_kdma['kdma'] == 'QualityOfLife':
+            if action_character is not None:
+                # Better quality of life patient
+                if expected_value > 5:
+                    cot_reasoning += f"Because {action_character.name} would have better quality of life post-treatment"
+                    # Sub-optimal treatment
+                    if expected_value == 7:
+                        cot_reasoning += f" but it is not the best treatment approach"
+                # Worse quality of life patient
+                elif expected_value < 5:
+                    cot_reasoning += f"Because {action_character.name} would have worse quality of life post-treatment"
+                    # Sub-optimal treatment
+                    if expected_value == 3:
+                        cot_reasoning += " but the supplies needed to treat the other casualty would still be available"
+
+        # Percieved quanity of lives saved
+        # Example:
+            # Because Casualty G would likely survive treatment, choosing Treat Casualty G with hemostatic gauze would score a 9 for the the principle of perceived quantity of lives saved.
+            # Because Casualty G would likely survive treatment but it is not the best treatment approach, choosing Treat Casualty G with pressure bandage would score a 7 for the the principle of perceived quantity of lives saved.
+            # Because Casualty H would likely not survive treatment but the supplies needed to treat the other casualty would still be available, choosing Treat Casualty H with pressure bandage would score a 3 for the the principle of perceived quantity of lives saved.
+            # Because Casualty H would likely not survive treatment, choosing Treat Casualty H with hemostatic gauze would score a 1 for the the principle of perceived quantity of lives saved.
+        elif target_kdma['kdma'] == 'PerceivedQuantityOfLivesSaved':
+            if action_character is not None:
+                # Better vol patient
+                if expected_value > 5:
+                    cot_reasoning += f"Because {action_character.name} would likely survive treatment"
+                    # Sub-optimal treatment
+                    if expected_value == 7:
+                        cot_reasoning += f" but it is not the best treatment approach"
+                # Worse quality of life patient
+                elif expected_value < 5:
+                    cot_reasoning += f"Because {action_character.name} would likely not survive treatment"
+                    # Sub-optimal treatment
+                    if expected_value == 3:
+                        cot_reasoning += " but the supplies needed to treat the other casualty would still be available"
+
+        # if a "because" statement has not been added
+        if cot_reasoning == '':
+            cot_reasoning = f"Choosing "
+        # else the reasoning will have form "Because ..., choosing ..."
         else:
-            raise ValueError(f'"{icl_strategy}" is not a valid incontext method. Please use "random" or '
-                                '"bert_similarity"')
+            cot_reasoning += ", choosing "
+        cot_reasoning += f"{choice} would score a {expected_value} for the the principle of {target_kdma['name']}."
 
-        return selected_icl_examples
-
-
-# Incontext helper function
-def get_chain_of_thought_reasoning(target_kdma, action, state, choice, label):
-    # Predicted scores are 0-10, KDMA values are 0-1
-    expected_value = int(label * 10)
-    cot_reasoning = ""
-
-    # get character associated with action
-    action_character = None
-    if hasattr(action, 'character_id') and action.character_id is not None:
-        for character in state.characters:
-            if character.id == action.character_id:
-                action_character = character
-                break
-
-    # Moral derivngess or moral judgement
-    # Example: Because Alex acted with no intent and did not cause of harm,
-    #          choosing Treat Alex would score a 5 for the the principle of moral judgement.
-    if target_kdma['kdma'] == 'MoralDesert' or  target_kdma['kdma'] == 'Moral judgement':
-        if action_character is not None:
-            # add intent to reasoning
-            if not hasattr(action_character, 'intent') or action_character.intent is None or action_character.intent == 'no intent':
-                cot_reasoning += f"Because {action_character.name} acted with no intent"
-            else:
-                cot_reasoning += f"Because {action_character.name} acted to {action_character.intent}"
-            # add directness of causality to reasoning
-            if not hasattr(action_character, 'directness_of_causality') or action_character.directness_of_causality is None or action_character.directness_of_causality == 'none':
-                    cot_reasoning += f" and did not cause of harm"
-            else:
-                cot_reasoning += f" and had a {action_character.directness_of_causality} cause of harm"
-
-    # Ingroup bias
-    # Example: Patient A is a soldier in your unit and is in group Allied US,
-    #           choosing to treat patient A would score a 6 for ingroup bias.
-    elif target_kdma['kdma'] == 'Ingroup Bias':
-        if action_character is not None:
-            # add unstructured charcter description to reasoning
-            if hasattr(action_character, 'unstructured') and action_character.unstructured is not None:
-                cot_reasoning += f"Because {action_character.name} is {action_character.unstructured.rstrip()}"
-                # add military disposition
-                if action_character.demographics['military_disposition'] is not None:
-                    cot_reasoning += f" and is in group {action_character.demographics['military_disposition']}"
-
-    # Quality of life
-    # Example
-        # Because Casualty X would have better quality of life post-treatment, choosing Treat Casualty X with a tourniquet would score a 9 for the the principle of quality of life.
-        # Because Casualty X would have better quality of life post-treatment but it is not the best treatment approach, choosing Treat Casualty X with hemostatic gauze would score a 7 for the the principle of quality of life.
-        # Because Casualty Y would have worse quality of life post-treatment but the supplies needed to treat the other casualty would still be available, choosing Treat Casualty Y with hemostatic gauze would score a 3 for the the principle of quality of life.
-        # Because Casualty Y would have worse quality of life post-treatment, choosing Treat Casualty Y with a tourniquet would score a 1 for the the principle of quality of life.
-    elif target_kdma['kdma'] == 'QualityOfLife':
-        if action_character is not None:
-            # Better quality of life patient
-            if expected_value > 5:
-                cot_reasoning += f"Because {action_character.name} would have better quality of life post-treatment"
-                # Sub-optimal treatment
-                if expected_value == 7:
-                    cot_reasoning += f" but it is not the best treatment approach"
-            # Worse quality of life patient
-            elif expected_value < 5:
-                cot_reasoning += f"Because {action_character.name} would have worse quality of life post-treatment"
-                # Sub-optimal treatment
-                if expected_value == 3:
-                    cot_reasoning += " but the supplies needed to treat the other casualty would still be available"
-
-    # Percieved quanity of lives saved
-    # Example:
-        # Because Casualty G would likely survive treatment, choosing Treat Casualty G with hemostatic gauze would score a 9 for the the principle of perceived quantity of lives saved.
-        # Because Casualty G would likely survive treatment but it is not the best treatment approach, choosing Treat Casualty G with pressure bandage would score a 7 for the the principle of perceived quantity of lives saved.
-        # Because Casualty H would likely not survive treatment but the supplies needed to treat the other casualty would still be available, choosing Treat Casualty H with pressure bandage would score a 3 for the the principle of perceived quantity of lives saved.
-        # Because Casualty H would likely not survive treatment, choosing Treat Casualty H with hemostatic gauze would score a 1 for the the principle of perceived quantity of lives saved.
-    elif target_kdma['kdma'] == 'PerceivedQuantityOfLivesSaved':
-        if action_character is not None:
-            # Better vol patient
-            if expected_value > 5:
-                cot_reasoning += f"Because {action_character.name} would likely survive treatment"
-                # Sub-optimal treatment
-                if expected_value == 7:
-                    cot_reasoning += f" but it is not the best treatment approach"
-            # Worse quality of life patient
-            elif expected_value < 5:
-                cot_reasoning += f"Because {action_character.name} would likely not survive treatment"
-                # Sub-optimal treatment
-                if expected_value == 3:
-                    cot_reasoning += " but the supplies needed to treat the other casualty would still be available"
-
-    # if a "because" statement has not been added
-    if cot_reasoning == '':
-        cot_reasoning = f"Choosing "
-    # else the reasoning will have form "Because ..., choosing ..."
-    else:
-        cot_reasoning += ", choosing "
-    cot_reasoning += f"{choice} would score a {expected_value} for the the principle of {target_kdma['name']}."
-
-    return cot_reasoning
+        return cot_reasoning

--- a/align_system/utils/incontext_utils.py
+++ b/align_system/utils/incontext_utils.py
@@ -1,0 +1,243 @@
+import json
+import torch
+import random
+from copy import deepcopy
+from abc import ABCMeta, abstractmethod
+
+
+from align_system.utils import adm_utils
+from align_system.utils import outlines_prompts_utils
+from align_system.utils.hydrate_state import hydrate_scenario_state
+from align_system.prompt_engineering.outlines_prompts import (
+    scenario_state_description_with_relevant_char_info,
+    comparative_kdma_score_prediction_prompt
+)
+
+
+class IncontextExampleGenerator(object, metaclass=ABCMeta):
+    '''
+    Abstract class for incontext example generator
+    '''
+    @abstractmethod
+    def __init__(self,
+                 incontext_settings, 
+                 target_kdmas, 
+                 log,
+                 **kwargs):
+        self.incontext_settings = incontext_settings
+        self.target_kdmas = target_kdmas
+        self.log = log
+        self.set_icl_datasets()
+
+    @abstractmethod
+    def set_icl_datasets(self):
+        '''
+        Sets the ICL datasets dictionary to pull examples from
+        '''
+        self.icl_datasets = {}
+        pass
+
+    @abstractmethod
+    def select_icl_examples(self):
+        '''
+        Returns relevant examples from self.icl_datasets
+        '''
+        pass
+
+
+class ComparativeRegressionIncontextExampleGenerator(IncontextExampleGenerator):
+    def __init__(self,
+                 incontext_settings, 
+                 target_kdmas, 
+                 log,
+                 **kwargs):
+        self.incontext_settings = incontext_settings
+        self.target_kdmas = target_kdmas
+        self.log = log
+        self.set_icl_datasets()
+    
+    def set_icl_datasets(self):
+        icl_datasets = {}
+        # Read dataset(s)
+        for target_kdma in self.target_kdmas:
+            dset_kdma = target_kdma['kdma']
+            dset_f = self.incontext_settings["datasets"][dset_kdma]
+            with open(dset_f) as f:
+                dset = json.load(f)
+
+            icl_datasets[dset_kdma] = []
+            for icl_sample in dset:
+                state, actions = hydrate_scenario_state(icl_sample["input"])
+                icl_choices = adm_utils.format_choices(
+                    [a.unstructured for a in actions],
+                    actions,
+                    state,
+                    self.log
+                )
+
+                icl_choices_with_outcomes = {}
+                for choice in icl_choices:
+                    # TODO: Include outcome prediction for ICL examples?
+                    icl_choices_with_outcomes[choice] = {'predicted_outcome':None}
+
+                character_info = outlines_prompts_utils.get_relevant_structured_character_info(state.characters)
+                icl_scenario_description = scenario_state_description_with_relevant_char_info(state, character_info)
+                icl_prompt = comparative_kdma_score_prediction_prompt(icl_scenario_description,
+                                                                    icl_choices_with_outcomes,
+                                                                    dset_kdma)
+                icl_reponse = {}
+                for action, icl_choice, label in zip(actions, icl_choices, icl_sample["label"]):
+                    if dset_kdma not in label:
+                        continue
+
+                    icl_reponse[icl_choice] = {}
+                    icl_reponse[icl_choice]['reasoning'] = get_chain_of_thought_reasoning(target_kdma, action,
+                                                                                            state, icl_choice,
+                                                                                            label[dset_kdma])
+                    # Predicted scores are 0-10, KDMA values are 0-1
+                    icl_reponse[icl_choice]['score'] = int(label[dset_kdma] * 10)
+
+                icl_datasets[dset_kdma].append({
+                    "scenario_description": icl_scenario_description,
+                    "prompt": icl_prompt,
+                    "response": icl_reponse
+                    })
+        self.icl_datasets = icl_datasets
+    
+    def select_icl_examples(self, sys_kdma_name, print_kdma_name, scenario_description, choices):
+        n_icl_examples = self.incontext_settings["number"]
+        if sys_kdma_name not in self.icl_datasets:
+            raise RuntimeError(f"No incontext samples for targeted kdma: {sys_kdma_name}")
+        possible_icl_examples = self.icl_datasets[sys_kdma_name]
+        if self.incontext_settings.get("leave_one_out", False):
+            # Don't include example ICL with exact same scenario state
+            possible_icl_examples = [
+                icl_ex for icl_ex in possible_icl_examples
+                if icl_ex["scenario_description"] != scenario_description
+            ]
+        if len(possible_icl_examples) < n_icl_examples:
+            raise RuntimeError(f"Not enough possible incontext samples to learn from. Only "
+                            f"{len(possible_icl_examples)} samples available while asking for "
+                            f"{n_icl_examples} incontext samples.")
+
+        # Downselect to n_icl_examples via given method
+        icl_strategy = self.incontext_settings["method"]
+        if icl_strategy == "random":
+            selected_icl_examples = random.sample(possible_icl_examples, n_icl_examples)
+        elif icl_strategy == "bert_similarity":
+            # TODO: Include outcome prediction for ICL examples?
+            no_outcome_predictions = {}
+            for choice in choices:
+                no_outcome_predictions[choice] = {}
+                no_outcome_predictions[choice]['predicted_outcome'] = None
+            no_outcome_prompt = comparative_kdma_score_prediction_prompt(scenario_description,
+                                                                            no_outcome_predictions,
+                                                                            print_kdma_name)
+
+            possible_icl_prompts = [icl_sample["prompt"] for icl_sample in possible_icl_examples]
+
+            # Create similarity scores between the ICL samples and find top-k indices
+            from bert_score import score
+            _, _, F1 = score([no_outcome_prompt]*len(possible_icl_prompts), possible_icl_prompts, lang="en")
+            _, indices = torch.topk(F1, n_icl_examples)
+
+            selected_icl_examples = [possible_icl_examples[i] for i in indices]
+        else:
+            raise ValueError(f'"{icl_strategy}" is not a valid incontext method. Please use "random" or '
+                                '"bert_similarity"')
+        return selected_icl_examples
+
+
+# Incontext helper function
+def get_chain_of_thought_reasoning(target_kdma, action, state, choice, label):
+    # Predicted scores are 0-10, KDMA values are 0-1
+    expected_value = int(label * 10)
+    cot_reasoning = ""
+
+    # get character associated with action
+    action_character = None
+    if hasattr(action, 'character_id') and action.character_id is not None:
+        for character in state.characters:
+            if character.id == action.character_id:
+                action_character = character
+                break
+
+    # Moral derivngess or moral judgement
+    # Example: Because Alex acted with no intent and did not cause of harm,
+    #          choosing Treat Alex would score a 5 for the the principle of moral judgement.
+    if target_kdma['kdma'] == 'MoralDesert' or  target_kdma['kdma'] == 'Moral judgement':
+        if action_character is not None:
+            # add intent to reasoning
+            if not hasattr(action_character, 'intent') or action_character.intent is None or action_character.intent == 'no intent':
+                cot_reasoning += f"Because {action_character.name} acted with no intent"
+            else:
+                cot_reasoning += f"Because {action_character.name} acted to {action_character.intent}"
+            # add directness of causality to reasoning
+            if not hasattr(action_character, 'directness_of_causality') or action_character.directness_of_causality is None or action_character.directness_of_causality == 'none':
+                    cot_reasoning += f" and did not cause of harm"
+            else:
+                cot_reasoning += f" and had a {action_character.directness_of_causality} cause of harm"
+
+    # Ingroup bias
+    # Example: Patient A is a soldier in your unit and is in group Allied US,
+    #           choosing to treat patient A would score a 6 for ingroup bias.
+    elif target_kdma['kdma'] == 'Ingroup Bias':
+        if action_character is not None:
+            # add unstructured charcter description to reasoning
+            if hasattr(action_character, 'unstructured') and action_character.unstructured is not None:
+                cot_reasoning += f"Because {action_character.name} is {action_character.unstructured.rstrip()}"
+                # add military disposition
+                if action_character.demographics['military_disposition'] is not None:
+                    cot_reasoning += f" and is in group {action_character.demographics['military_disposition']}"
+
+    # Quality of life
+    # Example
+        # Because Casualty X would have better quality of life post-treatment, choosing Treat Casualty X with a tourniquet would score a 9 for the the principle of quality of life.
+        # Because Casualty X would have better quality of life post-treatment but it is not the best treatment approach, choosing Treat Casualty X with hemostatic gauze would score a 7 for the the principle of quality of life.
+        # Because Casualty Y would have worse quality of life post-treatment but the supplies needed to treat the other casualty would still be available, choosing Treat Casualty Y with hemostatic gauze would score a 3 for the the principle of quality of life.
+        # Because Casualty Y would have worse quality of life post-treatment, choosing Treat Casualty Y with a tourniquet would score a 1 for the the principle of quality of life.
+    elif target_kdma['kdma'] == 'QualityOfLife':
+        if action_character is not None:
+            # Better quality of life patient
+            if expected_value > 5:
+                cot_reasoning += f"Because {action_character.name} would have better quality of life post-treatment"
+                # Sub-optimal treatment
+                if expected_value == 7:
+                    cot_reasoning += f" but it is not the best treatment approach"
+            # Worse quality of life patient
+            elif expected_value < 5:
+                cot_reasoning += f"Because {action_character.name} would have worse quality of life post-treatment"
+                # Sub-optimal treatment
+                if expected_value == 3:
+                    cot_reasoning += " but the supplies needed to treat the other casualty would still be available"
+
+    # Percieved quanity of lives saved
+    # Example:
+        # Because Casualty G would likely survive treatment, choosing Treat Casualty G with hemostatic gauze would score a 9 for the the principle of perceived quantity of lives saved.
+        # Because Casualty G would likely survive treatment but it is not the best treatment approach, choosing Treat Casualty G with pressure bandage would score a 7 for the the principle of perceived quantity of lives saved.
+        # Because Casualty H would likely not survive treatment but the supplies needed to treat the other casualty would still be available, choosing Treat Casualty H with pressure bandage would score a 3 for the the principle of perceived quantity of lives saved.
+        # Because Casualty H would likely not survive treatment, choosing Treat Casualty H with hemostatic gauze would score a 1 for the the principle of perceived quantity of lives saved.
+    elif target_kdma['kdma'] == 'PerceivedQuantityOfLivesSaved':
+        if action_character is not None:
+            # Better vol patient
+            if expected_value > 5:
+                cot_reasoning += f"Because {action_character.name} would likely survive treatment"
+                # Sub-optimal treatment
+                if expected_value == 7:
+                    cot_reasoning += f" but it is not the best treatment approach"
+            # Worse quality of life patient
+            elif expected_value < 5:
+                cot_reasoning += f"Because {action_character.name} would likely not survive treatment"
+                # Sub-optimal treatment
+                if expected_value == 3:
+                    cot_reasoning += " but the supplies needed to treat the other casualty would still be available"
+
+    # if a "because" statement has not been added
+    if cot_reasoning == '':
+        cot_reasoning = f"Choosing "
+    # else the reasoning will have form "Because ..., choosing ..."
+    else:
+        cot_reasoning += ", choosing "
+    cot_reasoning += f"{choice} would score a {expected_value} for the the principle of {target_kdma['name']}."
+
+    return cot_reasoning


### PR DESCRIPTION
This PR has the following reformatting:
- Moves the `format_choices()` function from the `OutlinesTransformersADM` class in `outlines_adm.py` to a new utils file: `adm_utils.py`. This function is used across ADMs and in ICL so it's better as a standalone function. 
- Moves the ICL functionality to `incontext_utils.py`

I created the abstract class `IncontextExampleGenerator()` with an abstract method `set_icl_datasets()` that is called in initalization. The `set_icl_datasets()` function creates a dataset of possible ICL examples for each target KDMA, where each example is a dictionary with keys `prompt` and `response`. With this setup, we can create different implementations of `IncontextExampleGenerator()` (as I did with `ComparativeRegressionIncontextExampleGenerator()`) that have specific prompts and responses. 

Then `IncontextExampleGenerator()` has a generic function `select_icl_examples(target_kdma, prompt_to_match)` that selects a subset of the examples for the target KDMA given the current probe (`prompt_to_match`). This is where the `random` and `bert_similarity` down-selection strategies are implemented, and we can add more. 

So when an ADM uses ICL, we first initialize a specific instance of `IncontextExampleGenerator()`. Then for each prompt, we call  `generator.select_icl_examples()` to get the relevant examples of `prompt` and `response` pairs. 