### PR TITLE
History-based cumulative KDE alignment option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Added a probabilistic option to alignment utilities. Exposed this option in oracle, comparative regression, and
   hybrid regression ADMs.
 * Example config for deterministic outlines-based ADM runs (`align_system/configs/experiment/examples/outlines_force_determinism.yaml`). Requires setting `force_determinsim` to true and using greedy sampler.
+* Added a history-based/cumulative KDE option to alignment utilities. Exposed this option in oracle and comparative regression.
 
 ### Fixed
 

--- a/align_system/algorithms/oracle_adm.py
+++ b/align_system/algorithms/oracle_adm.py
@@ -56,10 +56,9 @@ class OracleADM(ActionBasedADM):
         elif all_kde_targets:
             if distribution_matching == 'cumulative_kde':
                 alignment_function = alignment_utils.CumulativeJsDivergenceKdeAlignment()
-                selected_choice_id, probs, updated_choice_history = alignment_function(
+                selected_choice_id, probs = alignment_function(
                     gt_kdma_values, target_kdmas, self.choice_history, misaligned=self.misaligned, probabilistic=self.probabilistic
                 )
-                self.choice_history = updated_choice_history
             else:
                 if distribution_matching == 'sample':
                     alignment_function = alignment_utils.MinDistToRandomSampleKdeAlignment()
@@ -76,6 +75,13 @@ class OracleADM(ActionBasedADM):
             # TODO: Currently we assume all targets either have scalar values or KDES,
             #       Down the line, we should extend to handling multiple targets of mixed types
             raise ValueError("ADM does not currently support a mix of scalar and KDE targets.")
+
+        # Update choice history
+        for target_kdma in target_kdmas:
+            kdma = target_kdma['kdma']
+            if kdma not in self.choice_history:
+                self.choice_history[kdma] = []
+            self.choice_history[kdma].extend(gt_kdma_values[selected_choice_id][kdma])
 
         for action in available_actions:
             if selected_choice_id == action.action_id:

--- a/align_system/utils/alignment_utils.py
+++ b/align_system/utils/alignment_utils.py
@@ -227,7 +227,6 @@ class JsDivergenceKdeAlignment(AlignmentFunction):
         '''
         kdma_values = _handle_single_value(kdma_values, target_kdmas)
         _check_if_targets_are_kde(target_kdmas)
-        target_kdma = target_kdmas[0] # TODO extend to multi-KDMA target scenario
 
         # Get predicted KDE for each choice and get distance to target
         distances = []
@@ -261,7 +260,6 @@ class CumulativeJsDivergenceKdeAlignment(AlignmentFunction):
         '''
         kdma_values = _handle_single_value(kdma_values, target_kdmas)
         _check_if_targets_are_kde(target_kdmas)
-        target_kdma = target_kdmas[0] # TODO extend to multi-KDMA target scenario
 
         # Get predicted KDE for each choice and get distance to target
         distances = []

--- a/align_system/utils/alignment_utils.py
+++ b/align_system/utils/alignment_utils.py
@@ -280,12 +280,7 @@ class CumulativeJsDivergenceKdeAlignment(AlignmentFunction):
 
         selected_choice, probs = self._select_min_dist_choice(choices, distances, misaligned, probabilistic=probabilistic)
 
-        updated_choice_history = choice_history
-        for target_kdma in target_kdmas:
-            kdma = target_kdma['kdma']
-            updated_choice_history[kdma].append(np.mean(kdma_values[selected_choice][kdma]))
-
-        return selected_choice, probs, updated_choice_history
+        return selected_choice, probs
 
     def get_best_sample_index(self, kdma_values, target_kdmas, selected_choice, misaligned=False, kde_norm=None):
         # Use max likelihood as distance from a sample to the distribution because JS is disitribution to distribution


### PR DESCRIPTION
Adds a new alignment function which uses the JS divergence between the target and a cumulative KDE (constructed using choice history) . This option is added to the oracle and comparative regression ADMs. To use, specify `distribution_matching: cumulative_kde`