### PR TITLE
Choice info in input_output.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Moved the `format_choices()` function from the `OutlinesTransformersADM` class in `outlines_adm.py` to a new utils file: `adm_utils.py` so it can be used across ADMs.
 * Update example_data/input_output_files to use DRE training scenarios
 * Changed default config to use `outlines_transformers_structured_baseline` (rather than the older `single_kdma_baseline`)
+* Adjusted `choose_action()` to enable returning an ADM-specific `choice_info` dictionary that is written to the resulting `input_output.json` file
 
 ### Added
 
@@ -19,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   hybrid regression ADMs.
 * Example config for deterministic outlines-based ADM runs (`align_system/configs/experiment/examples/outlines_force_determinism.yaml`). Requires setting `force_determinsim` to true and using greedy sampler.
 * Added a history-based/cumulative KDE option to alignment utilities. Exposed this option in oracle and comparative regression.
+* Added true and predicted KDMA values to the log and `input_output.json` file for comparative regression ADM. 
 
 ### Fixed
 

--- a/align_system/algorithms/abstracts.py
+++ b/align_system/algorithms/abstracts.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from typing import Union
+from typing import Union, Tuple, Dict
 from swagger_client.models import State, Action, AlignmentTarget
 
 
@@ -10,7 +10,7 @@ class ActionBasedADM(ABC):
                       scenario_state: State,
                       available_actions: list[Action],
                       alignment_target: Union[type[AlignmentTarget], None],
-                      **kwargs) -> Action:
+                      **kwargs) -> Tuple[Action, Dict]:
         pass
 
 

--- a/align_system/algorithms/abstracts.py
+++ b/align_system/algorithms/abstracts.py
@@ -10,7 +10,7 @@ class ActionBasedADM(ABC):
                       scenario_state: State,
                       available_actions: list[Action],
                       alignment_target: Union[type[AlignmentTarget], None],
-                      **kwargs) -> Tuple[Action, Dict]:
+                      **kwargs) -> Union[Action, Tuple[Action, Dict]]:
         pass
 
 

--- a/align_system/algorithms/hybrid_kaleido_adm.py
+++ b/align_system/algorithms/hybrid_kaleido_adm.py
@@ -30,4 +30,5 @@ class HybridKaleidoADM(ActionBasedADM):
             action_to_take,
             dialog)
 
-        return action_to_take
+        choice_info = {}
+        return action_to_take, choice_info

--- a/align_system/algorithms/hybrid_kaleido_adm.py
+++ b/align_system/algorithms/hybrid_kaleido_adm.py
@@ -14,7 +14,7 @@ class HybridKaleidoADM(ActionBasedADM):
         self.outlines_adm = outlines_adm
 
     def choose_action(self, scenario_state, available_actions, alignment_target, **kwargs):
-        action_to_take = self.kaleido_adm.choose_action(
+        action_to_take, choice_info = self.kaleido_adm.choose_action(
             scenario_state, available_actions, alignment_target, **kwargs)
 
         # Build out initial dialog for the outlines ADM in order to
@@ -30,5 +30,4 @@ class HybridKaleidoADM(ActionBasedADM):
             action_to_take,
             dialog)
 
-        choice_info = {}
         return action_to_take, choice_info

--- a/align_system/algorithms/kaleido_adm.py
+++ b/align_system/algorithms/kaleido_adm.py
@@ -393,4 +393,5 @@ class KaleidoADM(AlignedDecisionMaker, ActionBasedADM):
         action_to_take = available_actions[selected_choice_idx]
         action_to_take.justification = kaleido_results.loc[selected_choice_idx, :].explanation
 
-        return action_to_take
+        choice_info = {}
+        return action_to_take, choice_info

--- a/align_system/algorithms/oracle_adm.py
+++ b/align_system/algorithms/oracle_adm.py
@@ -233,4 +233,6 @@ class OracleADM(ActionBasedADM):
                 ])
 
         action_to_take.justification = "Looked at scores"
-        return action_to_take
+
+        choice_info = {}
+        return action_to_take, choice_info

--- a/align_system/algorithms/outlines_adm.py
+++ b/align_system/algorithms/outlines_adm.py
@@ -368,7 +368,8 @@ class OutlinesTransformersADM(ActionBasedADM):
             action_to_take,
             dialog)
 
-        return action_to_take
+        choice_info = {}
+        return action_to_take, choice_info
 
     def populate_action_parameters(self, scenario_state, action_to_take, dialog):
         if action_to_take.action_type in {ActionTypeEnum.APPLY_TREATMENT,

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -311,6 +311,8 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
         log.info("Predicted KDMA Values:")
         log.info(json.dumps(predicted_kdma_values))
 
+        choice_info = {'true_kdma_values':true_kdma_values, 'predicted_kdma_values':predicted_kdma_values}
+
         # Get type of targets
         all_scalar_targets = True
         all_kde_targets = True
@@ -373,4 +375,19 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
         dialog = [{'role': 'system', 'content': alignment_system_prompt},
                   {'role': 'user', 'content': prompt}]
 
-        return action_to_take, dialog
+        return action_to_take, dialog, choice_info
+
+
+    def choose_action(self, scenario_state, available_actions, alignment_target, **kwargs):
+        action_to_take, dialog, choice_info = self.top_level_choose_action(
+            scenario_state,
+            available_actions,
+            alignment_target,
+            **kwargs)
+
+        action_to_take, dialog = self.populate_action_parameters(
+            scenario_state,
+            action_to_take,
+            dialog)
+
+        return action_to_take, choice_info

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -1,5 +1,6 @@
 import yaml
 import torch
+import json
 import numpy as np
 
 import outlines

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -300,6 +300,17 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
                                                         kdma_score_examples,
                                                         incontext_settings=kwargs.get("incontext", {}))
 
+        # Log true kdma values if present
+        true_kdma_values = {}
+        for choice_idx in range(len(available_actions)):
+            true_kdma_values[choices[choice_idx]] = available_actions[choice_idx].kdma_association
+        log.info("True KDMA Values:")
+        log.info(json.dumps(true_kdma_values))
+
+        # Log predicted kdma values
+        log.info("Predicted KDMA Values:")
+        log.info(json.dumps(predicted_kdma_values))
+
         # Get type of targets
         all_scalar_targets = True
         all_kde_targets = True

--- a/align_system/algorithms/persona_adm.py
+++ b/align_system/algorithms/persona_adm.py
@@ -258,7 +258,8 @@ class PersonaADM(AlignedDecisionMaker, ActionBasedADM):
                     scenario_state, action_to_take, alignment_target, **kwargs
                 )
 
-        return action_to_take
+        choice_info = {}
+        return action_to_take, choice_info
 
     def populate_treatment_parameters(self, scenario_state, treatment_action, alignment_target, **kwargs):
         from swagger_client.models import ActionTypeEnum

--- a/align_system/algorithms/random_adm.py
+++ b/align_system/algorithms/random_adm.py
@@ -61,4 +61,5 @@ class RandomADM(ActionBasedADM):
         # Required since Dry Run Evaluation
         action_to_take.justification = "Random choice"
 
-        return action_to_take
+        choice_info = {}
+        return action_to_take, choice_info

--- a/align_system/cli/run_align_system.py
+++ b/align_system/cli/run_align_system.py
@@ -272,11 +272,18 @@ def main(cfg: DictConfig) -> None:
                 # prevent ADMs from modifying the originals (should
                 # considering doing the same for current_state and
                 # alignment_target)
-                action_to_take, choice_info = adm.choose_action(
+                choose_action_result = adm.choose_action(
                     current_state,
                     [deepcopy(a) for a in available_actions_filtered],
                     alignment_target if cfg.align_to_target else None,
                     **cfg.adm.get('inference_kwargs', {}))
+
+                # Handle choose action result (for backwards compatibility if no choice_info)
+                if isinstance(choose_action_result, tuple):
+                    action_to_take, choice_info  = choose_action_result
+                else:
+                    action_to_take = choose_action_result
+                    choice_info = {}
 
                 end_choose_action = timer()
                 sce_times_s.append(end_choose_action - start_choose_action)

--- a/align_system/cli/run_align_system.py
+++ b/align_system/cli/run_align_system.py
@@ -272,7 +272,7 @@ def main(cfg: DictConfig) -> None:
                 # prevent ADMs from modifying the originals (should
                 # considering doing the same for current_state and
                 # alignment_target)
-                action_to_take = adm.choose_action(
+                action_to_take, choice_info = adm.choose_action(
                     current_state,
                     [deepcopy(a) for a in available_actions_filtered],
                     alignment_target if cfg.align_to_target else None,
@@ -302,6 +302,7 @@ def main(cfg: DictConfig) -> None:
                                              'state': current_state.unstructured,
                                              'choices': [a.to_dict() for a in available_actions]},
                                    'label': [{} if a.kdma_association is None else a.kdma_association for a in available_actions],
+                                   'choice_info': choice_info,
                                    'output': {'choice': action_choice_idx,
                                               'action': action_to_take.to_dict()}})
 


### PR DESCRIPTION
This PR adjusts `choose_action()` to return a dictionary called `choice_info` in addition to the action to take. The `choice_info` dictionary contains ADM-specific info that would be difficult to parse from the log. `run_align_system.py` is updated to write `choice_info` to the `input_output.json` file for easier parsing. 

For comparative regression, the true and predicted KDMA values are logged and added to `choice_info`. This enables calculating the regression accuracy (MSE) from resulting `input_output.json` files, using this script: https://github.com/ITM-Kitware/scratch/blob/dev/regression_mse/calculate_mse.py

I added an empty dictionary for `choice_info` to the other ADMs for now. This could be updated down the line to include relevant info, such as the positive and negative votes in `outlines_adm.py`.

Open to suggestions about better ways of doing this, since it is not ideal to return arbitrary output from `choose_action()`. 