### PR TITLE
Avoid potential divide by zero when misaligning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,13 +20,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   hybrid regression ADMs.
 * Example config for deterministic outlines-based ADM runs (`align_system/configs/experiment/examples/outlines_force_determinism.yaml`). Requires setting `force_determinsim` to true and using greedy sampler.
 * Added a history-based/cumulative KDE option to alignment utilities. Exposed this option in oracle and comparative regression.
-* Added true and predicted KDMA values to the log and `input_output.json` file for comparative regression ADM. 
+* Added true and predicted KDMA values to the log and `input_output.json` file for comparative regression ADM.
 
 ### Fixed
 
 * Fixed KDE target samples to be between 0 and 1
 * Fixed issue in alignment_utils logging (where kdma values can be a float/int rather than a list)
 * Now properly hydrating the meta_info field of input_output files
+* Fixed possible divide by zero during misaligned alignment
 
 ### Deprecated
 

--- a/align_system/utils/alignment_utils.py
+++ b/align_system/utils/alignment_utils.py
@@ -39,12 +39,18 @@ class AlignmentFunction(ABC):
         pass
 
     def _select_min_dist_choice(self, choices, dists, misaligned=False, probabilistic=False):
+        if len(dists) != len(choices):
+            raise RuntimeError("A distance must be provided for each choice during alignment")
+        if len(choices) == 0:
+            raise RuntimeError("No choices provided")
+
+        eps = 1e-16
         if not misaligned:
             # For aligned, want to minimize to distance to target
             # Invert distances so minimal distances have higher probability
 
             # Small epsilon for a perfect (0 distance) match
-            inv_dists = [1/(distance+1e-16) for distance in dists]
+            inv_dists = [1/(distance+eps) for distance in dists]
 
             # Convert inverse distances to probabilities
             probs = [inv_dist/sum(inv_dists) for inv_dist in inv_dists]
@@ -53,7 +59,8 @@ class AlignmentFunction(ABC):
             # maximize over non-inverted distances
 
             # Convert distances to probabilities
-            probs = [dist/sum(dists) for dist in dists]
+            # Avoid divide by zero if all distances are 0
+            probs = [dist/(sum(dists)+eps) for dist in dists]
 
         if probabilistic:
             selected_choice = np.random.choice(choices, p=probs)


### PR DESCRIPTION
Removes possibility for divide by zero if all distances are zero when "misaligning." Also adds some additional error checking