### PR TITLE
Small fixes for cumulative alignment 

### DIFF
--- a/align_system/algorithms/oracle_adm.py
+++ b/align_system/algorithms/oracle_adm.py
@@ -57,7 +57,7 @@ class OracleADM(ActionBasedADM):
             if distribution_matching == 'cumulative_kde':
                 alignment_function = alignment_utils.CumulativeJsDivergenceKdeAlignment()
                 selected_choice_id, probs = alignment_function(
-                    gt_kdma_values, target_kdmas, self.choice_history, misaligned=self.misaligned, probabilistic=self.probabilistic
+                    gt_kdma_values, target_kdmas, self.choice_history, misaligned=self.misaligned, kde_norm=kde_norm, probabilistic=self.probabilistic
                 )
             else:
                 if distribution_matching == 'sample':

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -332,7 +332,7 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
             if distribution_matching == 'cumulative_kde':
                 alignment_function = alignment_utils.CumulativeJsDivergenceKdeAlignment()
                 selected_choice, probs = alignment_function(
-                    predicted_kdma_values, target_kdmas, self.choice_history, probabilistic=self.probabilistic
+                    predicted_kdma_values, target_kdmas, self.choice_history, kde_norm=kde_norm, probabilistic=self.probabilistic
                 )
             else:
                 if distribution_matching == 'sample':

--- a/align_system/utils/alignment_utils.py
+++ b/align_system/utils/alignment_utils.py
@@ -186,7 +186,7 @@ class MaxLikelihoodKdeAlignment(AlignmentFunction):
                     target_kdma = target_kdma.to_dict()
 
                 target_kde = kde_utils.load_kde(target_kdma, kde_norm)
-                predicted_samples = kdma_values[choice][target_kdma.kdma]
+                predicted_samples = kdma_values[choice][target_kdma['kdma']]
                 log_likelihoods = target_kde.score_samples(np.array(predicted_samples).reshape(-1, 1))
                 total_likelihood += np.sum(np.exp(log_likelihoods))
             likelihoods.append(total_likelihood)
@@ -269,11 +269,11 @@ class CumulativeJsDivergenceKdeAlignment(AlignmentFunction):
             for target_kdma in target_kdmas:
                 if isinstance(target_kdma, KDMAValue):
                     target_kdma = target_kdma.to_dict()
-                if target_kdma.kdma not in choice_history:
-                    choice_history[target_kdma.kdma] = []
+                if target_kdma['kdma'] not in choice_history:
+                    choice_history[target_kdma['kdma']] = []
                 target_kde = kde_utils.load_kde(target_kdma, kde_norm)
-                predicted_samples = kdma_values[choice][target_kdma.kdma]
-                history_and_predicted_samples = choice_history[target_kdma.kdma] + [np.mean(predicted_samples)]
+                predicted_samples = kdma_values[choice][target_kdma['kdma']]
+                history_and_predicted_samples = choice_history[target_kdma['kdma']] + [np.mean(predicted_samples)]
                 predicted_kde = kde_utils.get_kde_from_samples(history_and_predicted_samples)
                 distance += kde_utils.js_distance(target_kde, predicted_kde, 100)
             distances.append(distance)


### PR DESCRIPTION
Small PR to:
- Fix bug - add missing kde_norm option for cumulative kde alignment
- Fix cumulative kde alignment to use dictionary syntax for the target_kdma since we call `target_kdma.to_dict()`

I don't think we need to update the change log for these small fixes 