### PR TITLE
Adding option to sort ICL examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 This changelog follows the specifications detailed in: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), although we have not yet reached a `1.0.0` release.
 
+## Unreleased
+
+### Changed
+
+* Changed `incontext` `normalization` setting to be off (null/rawscores)
+
+### Added
+
+* Added `incontext` an option for sorting examples responses: `sort_actions`
+  
 ## 0.5.3
 
 ### Changed

--- a/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
@@ -7,8 +7,11 @@ inference_kwargs:
     number: 5
     method: prompt_bert_similarity
     leave_one_out: false
-    normalization: null
-    sort_actions: true
+    normalization: globalnorm
     datasets:
-      QualityOfLife: /data/shared/samba/phase1_icl/qol_train1_20241105.json
-      PerceivedQuantityOfLivesSaved: /data/shared/samba/phase1_icl/vol_train1_20241105.json
+      MoralDesert: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_adept_high-1715105775-input-output.json
+      maximization: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_soartech_high-1716581856-input-output.json
+      Moral judgement: /data/shared/samba/dry_run/moral_judgement_20240826.json
+      Ingroup Bias: /data/shared/samba/dry_run/ingroup_bias_20240826.json
+      QualityOfLife: /data/shared/samba/dry_run/qol_20240826.json
+      PerceivedQuantityOfLivesSaved: /data/shared/samba/dry_run/vol_20240826.json

--- a/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
@@ -7,11 +7,8 @@ inference_kwargs:
     number: 5
     method: prompt_bert_similarity
     leave_one_out: false
-    normalization: globalnorm
+    normalization: null
+    sort_actions: true
     datasets:
-      MoralDesert: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_adept_high-1715105775-input-output.json
-      maximization: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_soartech_high-1716581856-input-output.json
-      Moral judgement: /data/shared/samba/dry_run/moral_judgement_20240826.json
-      Ingroup Bias: /data/shared/samba/dry_run/ingroup_bias_20240826.json
-      QualityOfLife: /data/shared/samba/dry_run/qol_20240826.json
-      PerceivedQuantityOfLivesSaved: /data/shared/samba/dry_run/vol_20240826.json
+      QualityOfLife: /data/shared/samba/phase1_icl/qol_train1_20241105.json
+      PerceivedQuantityOfLivesSaved: /data/shared/samba/phase1_icl/vol_train1_20241105.json

--- a/align_system/configs/adm/outlines_regression_aligned_comparative/incontext_phase1.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned_comparative/incontext_phase1.yaml
@@ -1,0 +1,14 @@
+defaults:
+  - outlines_regression_aligned_comparative
+
+inference_kwargs:
+  generator_batch_size: 5
+  incontext:
+    number: 5
+    method: prompt_bert_similarity
+    leave_one_out: false
+    normalization: null
+    sort_actions: true
+    datasets:
+      QualityOfLife: /data/shared/samba/phase1_icl/qol_train1_20241105.json
+      PerceivedQuantityOfLivesSaved: /data/shared/samba/phase1_icl/vol_train1_20241105.json

--- a/align_system/utils/incontext_utils.py
+++ b/align_system/utils/incontext_utils.py
@@ -74,6 +74,12 @@ class IncontextExampleGenerator(object, metaclass=ABCMeta):
                 for icl_sample in dset:
                     # Get state and actions
                     state, actions = hydrate_scenario_state(icl_sample["input"])
+                    labels = icl_sample["label"]
+                    if self.incontext_settings.sort_actions:
+                        # Impose a fixed ordering of available actions and labels to help with determinism
+                        combined = list(zip(actions, labels))
+                        combined_sorted = sorted(combined, key=lambda x: x[0].unstructured)
+                        actions, labels = zip(*combined_sorted)
                     # Get choices
                     choices = adm_utils.format_choices(
                         [a.unstructured for a in actions],
@@ -82,7 +88,7 @@ class IncontextExampleGenerator(object, metaclass=ABCMeta):
                     )
                     # Get KDMA_values
                     kdma_values = []
-                    for label in icl_sample["label"]:
+                    for label in labels:
                         if sys_kdma_name not in label:
                             kdma_values.append(None)
                         else:


### PR DESCRIPTION
Adds option to sort ICL examples responses (`sort_actions` in the `incontext` settings). 
This enables matching the ICL and probe response order when `sort_available_actions: true`