### PR TITLE
Add character-based LOO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 * Changed `incontext` `normalization` setting to be off (null/rawscores)
+* ``incontext.leave_one_out=false`` should now be configured as ``incontext.leave_one_out=null``. Default behavior is **no** leave one out behavior.
+  Previous ``incontext.leave_one_out=true`` should be specified as ``incontext.leave_one_out=scenario_description``. Additionally, duplicate ICL examples,
+  based on the chosen similiarity strategy, are now removed.
 
 ### Added
 
 * Added `incontext` an option for sorting examples responses: `sort_actions`
-  
+* Added character-based leave one out option: ``incontext.leave_one_out=characters``
+* Phase 1 experiments directory
+
 ## 0.5.3
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 * Changed `incontext` `normalization` setting to be off (null/rawscores)
-* ``incontext.leave_one_out=false`` should now be configured as ``incontext.leave_one_out=null``. Default behavior is **no** leave one out behavior.
-  Previous ``incontext.leave_one_out=true`` should be specified as ``incontext.leave_one_out=scenario_description``. Additionally, duplicate ICL examples,
+* ``incontext.leave_one_out=false`` should now be configured as ``incontext.leave_one_out_strategy=null``. Default behavior is **no** leave one out behavior.
+  Previous ``incontext.leave_one_out=true`` should be specified as ``incontext.leave_one_out_strategy=scenario_description``. Additionally, duplicate ICL examples,
   based on the chosen similiarity strategy, are now removed.
 
 ### Added
 
 * Added `incontext` an option for sorting examples responses: `sort_actions`
-* Added character-based leave one out option: ``incontext.leave_one_out=characters``
+* Added character-based leave one out option: ``incontext.leave_one_out_strategy=characters``
 * Phase 1 experiments directory
 
 ## 0.5.3

--- a/align_system/algorithms/oracle_adm.py
+++ b/align_system/algorithms/oracle_adm.py
@@ -34,9 +34,9 @@ class OracleADM(ActionBasedADM):
         all_scalar_targets = True
         all_kde_targets = True
         for target_kdma in target_kdmas:
-            if not hasattr(target_kdma, 'value') or target_kdma.value is None:
+            if 'value' not in target_kdma or target_kdma['value'] is None:
                 all_scalar_targets = False
-            if not hasattr(target_kdma, 'kdes') or target_kdma.kdes is None:
+            if 'kdes' not in target_kdma or target_kdma['kdes'] is None:
                 all_kde_targets = False
 
         # get ground truth kdma values

--- a/align_system/algorithms/outlines_adm.py
+++ b/align_system/algorithms/outlines_adm.py
@@ -218,22 +218,25 @@ class OutlinesTransformersADM(ActionBasedADM):
             if "incontext" in kwargs and "number" in incontext_settings and incontext_settings["number"] > 0:
                 scenario_to_match = scenario_state_description_1(scenario_state)
                 prompt_to_match, _ = self._state_to_top_level_prompt(scenario_state, available_actions)
-                
+
                 # Create positive ICL example generators
                 positive_target = {'kdma': kdma, 'name': name, 'value': value}
                 positive_icl_example_generator = incontext_utils.BaselineIncontextExampleGenerator(incontext_settings,
                                                                                                     [positive_target])
                 # Get subset of relevant of examples
-                positive_selected_icl_examples = positive_icl_example_generator.select_icl_examples(kdma, 
-                                                                                                    scenario_to_match, 
-                                                                                                    prompt_to_match)
+                positive_selected_icl_examples = positive_icl_example_generator.select_icl_examples(
+                    sys_kdma_name=kdma,
+                    scenario_description_to_match=scenario_to_match,
+                    prompt_to_match=prompt_to_match,
+                    state_comparison=scenario_state
+                )
                 # Create positive ICL prompts
                 for icl_sample in positive_selected_icl_examples:
                     positive_icl_examples.extend([
                         {"role": "user", "content": icl_sample['prompt']},
                         {"role": "assistant", "content": f'{icl_sample["response"]}'}
                     ])
-                
+
                 # Create negative ICL prompts
                 if num_negative_samples > 0:
                     # Create negative ICL example generators
@@ -241,9 +244,12 @@ class OutlinesTransformersADM(ActionBasedADM):
                     negative_icl_example_generator = incontext_utils.BaselineIncontextExampleGenerator(incontext_settings,
                                                                                                     [negative_target])
                     # Get subset of relevant of examples
-                    negative_selected_icl_examples = negative_icl_example_generator.select_icl_examples(kdma, 
-                                                                                                    scenario_to_match, 
-                                                                                                    prompt_to_match)
+                    negative_selected_icl_examples = negative_icl_example_generator.select_icl_examples(
+                        sys_kdma_name=kdma,
+                        scenario_description_to_match=scenario_to_match,
+                        prompt_to_match=prompt_to_match,
+                        state_comparison=scenario_state
+                    )
                     for icl_sample in negative_selected_icl_examples:
                         negative_icl_examples.extend([
                             {"role": "user", "content": icl_sample['prompt']},

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -113,6 +113,7 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
         return predicted_outcomes
 
     def sample_kdma_score_predictions(self,
+                                      scenario_state,
                                       scenario_description,
                                       choices,
                                       target_kdmas,
@@ -156,9 +157,12 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
                     prompt_to_match = comparative_kdma_score_prediction_prompt(scenario_description,
                                                                                     no_outcome_predictions,
                                                                                     target_kdma['name'])
-                    selected_icl_examples = icl_example_generator.select_icl_examples(target_kdma['kdma'],
-                                                                                      scenario_description,
-                                                                                      prompt_to_match)
+                    selected_icl_examples = icl_example_generator.select_icl_examples(
+                        sys_kdma_name=target_kdma['kdma'],
+                        scenario_description_to_match=scenario_description,
+                        prompt_to_match=prompt_to_match,
+                        state_comparison=scenario_state,
+                    )
                     for icl_sample in selected_icl_examples:
                         icl_examples.extend([
                             {"role": "user", "content": icl_sample['prompt']},
@@ -295,11 +299,11 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
 
 
         # Predict kdma values
-        predicted_kdma_values, reasonings = self.sample_kdma_score_predictions(scenario_description,
-                                                        choices, target_kdmas, outcome_predictions,
-                                                        num_samples, generator_batch_size,
-                                                        kdma_score_examples,
-                                                        incontext_settings=kwargs.get("incontext", {}))
+        predicted_kdma_values, reasonings = self.sample_kdma_score_predictions(
+            scenario_state, scenario_description, choices, target_kdmas, outcome_predictions,
+            num_samples, generator_batch_size, kdma_score_examples,
+            incontext_settings=kwargs.get("incontext", {})
+        )
 
         # Log true kdma values if present
         true_kdma_values = {}

--- a/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
@@ -6,7 +6,7 @@ inference_kwargs:
   incontext:
     number: 5
     method: prompt_bert_similarity
-    leave_one_out: false
+    leave_one_out: null
     normalization: globalnorm
     datasets:
       MoralDesert: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_adept_high-1715105775-input-output.json

--- a/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned_comparative/incontext.yaml
@@ -6,7 +6,7 @@ inference_kwargs:
   incontext:
     number: 5
     method: prompt_bert_similarity
-    leave_one_out: null
+    leave_one_out_strategy: null
     normalization: globalnorm
     datasets:
       MoralDesert: /data/shared/samba/integrated_results_metrics_eval/captured_dataset_for_chris/baseline_adept_high-1715105775-input-output.json

--- a/align_system/configs/adm/outlines_regression_aligned_comparative/incontext_phase1.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned_comparative/incontext_phase1.yaml
@@ -6,7 +6,7 @@ inference_kwargs:
   incontext:
     number: 5
     method: prompt_bert_similarity
-    leave_one_out: null
+    leave_one_out_strategy: null
     normalization: null
     sort_actions: true
     datasets:

--- a/align_system/configs/adm/outlines_regression_aligned_comparative/incontext_phase1.yaml
+++ b/align_system/configs/adm/outlines_regression_aligned_comparative/incontext_phase1.yaml
@@ -6,9 +6,11 @@ inference_kwargs:
   incontext:
     number: 5
     method: prompt_bert_similarity
-    leave_one_out: false
+    leave_one_out: null
     normalization: null
     sort_actions: true
     datasets:
       QualityOfLife: /data/shared/samba/phase1_icl/qol_train1_20241105.json
       PerceivedQuantityOfLivesSaved: /data/shared/samba/phase1_icl/vol_train1_20241105.json
+      Moral judgement: /data/shared/samba/phase1_icl/moral_judgement_20241106.json
+      Ingroup Bias: /data/shared/samba/phase1_icl/ingroup_bias_20241106_no_IO2.json

--- a/align_system/configs/experiment/phase1_evaluation/random_adept_ingroup_bias_train.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/random_adept_ingroup_bias_train.yaml
@@ -1,0 +1,18 @@
+# @package _global_
+defaults:
+  - override /adm: random
+  - override /interface: ta3
+
+interface:
+  api_endpoint: "http://127.0.0.1:8089"
+  session_type: adept
+  scenario_ids:
+    - DryRunEval.IO1
+    - DryRunEval.IO1-w-events
+    - DryRunEval.IO1exp
+    - DryRunEval.IO1v2
+    - DryRunEval.IO2
+    - DryRunEval.IO3
+  training_session: true
+
+align_to_target: true

--- a/align_system/configs/experiment/phase1_evaluation/random_adept_moral_judgement_train.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/random_adept_moral_judgement_train.yaml
@@ -1,0 +1,15 @@
+# @package _global_
+defaults:
+  - override /adm: random
+  - override /interface: ta3
+
+interface:
+  api_endpoint: "http://127.0.0.1:8089"
+  session_type: adept
+  scenario_ids:
+    - DryRunEval.MJ1
+    - DryRunEval.MJ1-w-events
+    - DryRunEval.MJ3
+  training_session: true
+
+align_to_target: true

--- a/align_system/utils/incontext_utils.py
+++ b/align_system/utils/incontext_utils.py
@@ -164,20 +164,20 @@ class IncontextExampleGenerator(object, metaclass=ABCMeta):
                             f"{len(possible_icl_examples)} samples available while asking for "
                             f"{n_icl_examples} incontext samples.")
         # If using LOO, don't include example ICL with exact same scenario description
-        loo_setting = self.incontext_settings.get("leave_one_out", None)
-        if loo_setting == "scenario_description":
+        loo_strategy = self.incontext_settings.get("leave_one_out_strategy", None)
+        if loo_strategy == "scenario_description":
             possible_icl_examples = [
                 icl_ex for icl_ex in possible_icl_examples
                 if icl_ex["scenario_description"] != scenario_description_to_match
             ]
-        elif loo_setting == "characters":
+        elif loo_strategy == "characters":
             possible_icl_examples = [
                 icl_ex for icl_ex in possible_icl_examples
                 if icl_ex["state"].characters != state_comparison.characters
             ]
-        elif loo_setting is not None:
+        elif loo_strategy is not None:
             raise ValueError(
-                f"Unknown leave one out setting '{loo_setting}'."
+                f"Unknown leave one out setting '{loo_strategy}'."
                 "Please choose from 'scenario_description' or 'characters'"
             )
 


### PR DESCRIPTION
Adds character based LOO. Removes duplicate ICL examples, based on configured similarity measure. Phase 1 experiment directory created.

Note:
- `incontext.leave_one_out=false`  should now be specified as `incontext.leave_one_out=null`
- `incontext.leave_one_out=true`  should now be specified as `incontext.leave_one_out=scenario_description` (old behavior) or `incontext.leave_one_out=characters`  