### PR TITLE
Adding history-based scalar target alignment 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Added character-based leave one out option: ``incontext.leave_one_out_strategy=characters``
 * Phase 1 experiments directory
 * Added the option to filter out TAG CHARACTER responses by setting `filter_tag_character` to true
+* Added a history-based alignment function for scalar targets that uses distance to a running mean. To use specify `inference_kwargs.distribution_matching` as `cumulative_average`
 
 ## 0.5.3
 

--- a/align_system/algorithms/oracle_adm.py
+++ b/align_system/algorithms/oracle_adm.py
@@ -48,10 +48,18 @@ class OracleADM(ActionBasedADM):
                 actions_with_kdma_values.append(action)
 
         if all_scalar_targets:
-            alignment_function = alignment_utils.AvgDistScalarAlignment()
-            selected_choice_id, probs = alignment_function(
-                gt_kdma_values, target_kdmas, misaligned=self.misaligned, probabilistic=self.probabilistic
-            )
+            if distribution_matching == 'average':
+                alignment_function = alignment_utils.AvgDistScalarAlignment()
+                selected_choice_id, probs = alignment_function(
+                    gt_kdma_values, target_kdmas, misaligned=self.misaligned, probabilistic=self.probabilistic
+                )
+            elif distribution_matching == 'cumulative_average':
+                alignment_function = alignment_utils.CumulativeAvgDistScalarAlignment()
+                selected_choice_id, probs = alignment_function(
+                    gt_kdma_values, target_kdmas, self.choice_history, misaligned=self.misaligned, kde_norm=kde_norm, probabilistic=self.probabilistic
+                )
+            else:
+                raise RuntimeError(distribution_matching, "distribution matching function unrecognized for scalar targets.")
 
         elif all_kde_targets:
             if distribution_matching == 'cumulative_kde':


### PR DESCRIPTION
Adds history-based (running mean) alignment function for scalar targets.  Added only to oracle ADM for now. 