### PR TITLE
Dev/quickfix for ta3 training mode flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * ``incontext.leave_one_out=false`` should now be configured as ``incontext.leave_one_out_strategy=null``. Default behavior is **no** leave one out behavior.
   Previous ``incontext.leave_one_out=true`` should be specified as ``incontext.leave_one_out_strategy=scenario_description``. Additionally, duplicate ICL examples,
   based on the chosen similiarity strategy, are now removed.
+* Changed `training_session` flag for TA3 interface from boolean to string (expecting "full" or "solo" or None)
 
 ### Added
 

--- a/align_system/configs/experiment/phase1_evaluation/comp_reg_adept_ingroup_bias_train.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/comp_reg_adept_ingroup_bias_train.yaml
@@ -13,7 +13,7 @@ interface:
     - DryRunEval.IO1v2
     - DryRunEval.IO2
     - DryRunEval.IO3
-  training_session: true
+  training_session: full
 
 adm:
   instance:

--- a/align_system/configs/experiment/phase1_evaluation/comp_reg_adept_ingroup_bias_train_sample.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/comp_reg_adept_ingroup_bias_train_sample.yaml
@@ -13,7 +13,7 @@ interface:
     - DryRunEval.IO1v2
     - DryRunEval.IO2
     - DryRunEval.IO3
-  training_session: true
+  training_session: full
 
 adm:
   instance:

--- a/align_system/configs/experiment/phase1_evaluation/comp_reg_adept_moral_judgement_train.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/comp_reg_adept_moral_judgement_train.yaml
@@ -10,7 +10,7 @@ interface:
     - DryRunEval.MJ1
     - DryRunEval.MJ1-w-events
     - DryRunEval.MJ3
-  training_session: true
+  training_session: full
 
 adm:
   instance:

--- a/align_system/configs/experiment/phase1_evaluation/comp_reg_adept_moral_judgement_train_sample.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/comp_reg_adept_moral_judgement_train_sample.yaml
@@ -10,7 +10,7 @@ interface:
     - DryRunEval.MJ1
     - DryRunEval.MJ1-w-events
     - DryRunEval.MJ3
-  training_session: true
+  training_session: full
 
 adm:
   instance:

--- a/align_system/configs/experiment/phase1_evaluation/comp_reg_soartech_train.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/comp_reg_soartech_train.yaml
@@ -6,7 +6,7 @@ defaults:
 interface:
   api_endpoint: "http://127.0.0.1:8089"
   session_type: soartech
-  training_session: true
+  training_session: full
 
 adm:
   instance:

--- a/align_system/configs/experiment/phase1_evaluation/oracle_soartech_train.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/oracle_soartech_train.yaml
@@ -6,7 +6,7 @@ defaults:
 interface:
   api_endpoint: "http://127.0.0.1:8089"
   session_type: soartech
-  training_session: true
+  training_session: full
 
 adm:
   inference_kwargs:

--- a/align_system/configs/experiment/phase1_evaluation/random_adept_ingroup_bias_train.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/random_adept_ingroup_bias_train.yaml
@@ -13,6 +13,6 @@ interface:
     - DryRunEval.IO1v2
     - DryRunEval.IO2
     - DryRunEval.IO3
-  training_session: true
+  training_session: full
 
 align_to_target: true

--- a/align_system/configs/experiment/phase1_evaluation/random_adept_moral_judgement_train.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/random_adept_moral_judgement_train.yaml
@@ -10,6 +10,6 @@ interface:
     - DryRunEval.MJ1
     - DryRunEval.MJ1-w-events
     - DryRunEval.MJ3
-  training_session: true
+  training_session: full
 
 align_to_target: true

--- a/align_system/configs/experiment/phase1_evaluation/random_soartech_train.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/random_soartech_train.yaml
@@ -6,4 +6,4 @@ defaults:
 interface:
   api_endpoint: "http://127.0.0.1:8089"
   session_type: soartech
-  training_session: true
+  training_session: full


### PR DESCRIPTION
FYSA @jadie1 @eveenhuis 

I updated the `training_session` config flags for the phase1 experiment files but didn't touch any others (with the idea that those older config files would work with older versions of the server rather than trying to ensure forward compatibility, but I could be talked into changing those also)