### PR TITLE
Option for all unique structured character info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Previous ``incontext.leave_one_out=true`` should be specified as ``incontext.leave_one_out_strategy=scenario_description``. Additionally, duplicate ICL examples,
   based on the chosen similiarity strategy, are now removed.
 * Changed `training_session` flag for TA3 interface from boolean to string (expecting "full" or "solo" or None)
-* Changed the comparative regression prompt to only include the structured chararcter information listed in `relevant_structured_character_info` in `kdma_descriptions.yaml` rather than including all unique character information
+* Changed the comparative regression prompt to only include the structured chararcter information listed in `relevant_structured_character_info` in `kdma_descriptions.yaml`. To include all strucutured information that is unique across characters in the prompt (as was previously done automatically), specify `relevant_structured_character_info = ['all_unique']`.
 * Improved the QoL `description` and `score_examples` in `kdma_descriptions.yaml`
 
 ### Added

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -302,7 +302,13 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
                     raise RuntimeError("Unknown valid scores option, expecting 'values' or 'range'")
                 target_kdmas[kdma_idx].update(kdma_descriptions[kdma])
 
-        character_info = outlines_prompts_utils.get_relevant_structured_character_info(scenario_state.characters, target_kdmas)
+        relevant_fields = []
+        for target_kdma in target_kdmas:
+            relevant_fields.extend(target_kdma['relevant_structured_character_info'])
+        if 'all_unique' in relevant_fields:
+            character_info = outlines_prompts_utils.get_unique_structured_character_info(scenario_state.characters)
+        else:
+            character_info = outlines_prompts_utils.get_relevant_structured_character_info(scenario_state.characters, target_kdmas)
         scenario_description = scenario_state_description_with_relevant_char_info(scenario_state, character_info)
 
         # Predict outcome of selecting each choice - optional

--- a/align_system/prompt_engineering/kdma_descriptions.yml
+++ b/align_system/prompt_engineering/kdma_descriptions.yml
@@ -8,7 +8,7 @@ Ingroup Bias:
       min: 0
       max: 100
       step: 1
-  relevant_structured_character_info: ['rapport', 'demographics.military_disposition', 'demographics.military_branch']
+  relevant_structured_character_info: ['all_unique']
 
 Moral judgement:
   name: moral judgment
@@ -20,7 +20,7 @@ Moral judgement:
       min: 0
       max: 100
       step: 1
-  relevant_structured_character_info: ['intent', 'directness_of_causality']
+  relevant_structured_character_info: ['intent', 'directness_of_causality', 'injuries']
 
 PerceivedQuantityOfLivesSaved:
   name: perceived quantity of lives saved

--- a/align_system/utils/incontext_utils.py
+++ b/align_system/utils/incontext_utils.py
@@ -311,7 +311,13 @@ class ComparativeRegressionIncontextExampleGenerator(IncontextExampleGenerator):
                 validate(instance=icl_response, schema=correct_schema)
 
                 # Get example prompt
-                character_info = outlines_prompts_utils.get_relevant_structured_character_info(example['state'].characters, self.target_kdmas)
+                relevant_fields = []
+                for target_kdma in self.target_kdmas:
+                    relevant_fields.extend(target_kdma['relevant_structured_character_info'])
+                if 'all_unique' in relevant_fields:
+                    character_info = outlines_prompts_utils.get_unique_structured_character_info(example['state'].characters)
+                else:
+                    character_info = outlines_prompts_utils.get_relevant_structured_character_info(example['state'].characters, self.target_kdmas)
                 icl_scenario_description = scenario_state_description_with_relevant_char_info(example['state'], character_info)
                 # Only include choices in the prompt if they are in the response
                 included_icl_choices_with_outcomes = {}


### PR DESCRIPTION
Adds an option to include all unique structured character info in the comparative regression prompt. To use, set  `relevant_structured_character_info: ['all_unique']`in `kdma_descriptions.yml`