### PR TITLE
Fixing indentation error for multi-kdma ICL

### DIFF
--- a/align_system/utils/incontext_utils.py
+++ b/align_system/utils/incontext_utils.py
@@ -107,7 +107,7 @@ class IncontextExampleGenerator(object, metaclass=ABCMeta):
                         raise ValueError(f'{self.incontext_settings["normalization"]} is not a valid incontext normalization option. '
                                         'Please use "globalnorm" or "localnorm".')
 
-            return incontext_data
+        return incontext_data
 
     def _global_normalization(self, incontext_data):
         for kdma in list(incontext_data.keys()):


### PR DESCRIPTION
Fixing an indentation error that was making it so only the first KDMA was included in the incontext dataset. With this fix alignment to multi-kdma targets works 