### PR TITLE
Action type based ICL selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Added KDMA scaling factor option. Scale factors for each KDMA are added to `align_system/prompt_engineering/kdma_descriptions.yml`
 * Added heuristic treatment options component
 * Added incontext examples to the `input_output.json` files for comparative regression
+* Added ICL example selection method that gives larger weight to examples with the same action types as the current probe. To use set `incontext.method` to `matching_actions`.
 
 ### Fixed
 

--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -121,6 +121,7 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
                                       scenario_description,
                                       choices,
                                       target_kdmas,
+                                      available_actions,
                                       outcome_predictions,
                                       num_samples=1,
                                       batch_size=6,
@@ -172,6 +173,7 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
                         scenario_description_to_match=scenario_description,
                         prompt_to_match=prompt_to_match,
                         state_comparison=scenario_state,
+                        actions=available_actions
                     )
                     for icl_sample in selected_icl_examples:
                         icl_examples.extend([
@@ -331,7 +333,7 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
 
         # Predict kdma values
         predicted_kdma_values, reasonings, icl_example_responses = self.sample_kdma_score_predictions(
-            scenario_state, scenario_description, choices, target_kdmas, outcome_predictions,
+            scenario_state, scenario_description, choices, target_kdmas, available_actions, outcome_predictions,
             num_samples, generator_batch_size, kdma_score_examples, enum_scores,
             incontext_settings=kwargs.get("incontext", {})
         )


### PR DESCRIPTION
Added ICL example selection method that gives larger weight to examples with the same action types as the current probe. To use set `incontext.method` to `matching_actions`.

If there are no ICL examples with the same action types then `prompt_bert_similarity` is used. 