### PR TITLE
Add character based ICL selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Added heuristic treatment options component
 * Added incontext examples to the `input_output.json` files for comparative regression
 * Added ICL example selection method that gives larger weight to examples with the same action types as the current probe. To use set `incontext.method` to `matching_actions`.
+* Added ICL example selection method that gives larger weight to examples with the same characetr ids as the current probe. To use set `incontext.method` to `matching_characters`.
 
 ### Fixed
 


### PR DESCRIPTION
This PR adds another ICL selection method. This one gives larger weight to examples with the same character ids as the current probe. To use set `incontext.method` to `matching_characters`.

If there are none with matching characters it uses the prompt bert similarity to select. 