### PR TITLE
Add multi-KDMA targets for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 * Added raw log output file (on by default) in addition to rich formatted log output file
 * Added choice_info output to KaleidoADM to support MSE analysis
+* Added multi-KDMA alignment targets for testing
 
 ### Changed
 

--- a/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Ingroup Bias-IO-high_MJ-high.yaml
+++ b/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Ingroup Bias-IO-high_MJ-high.yaml
@@ -1,0 +1,8 @@
+_target_: swagger_client.models.AlignmentTarget
+
+id: ADEPT-DryRun-Ingroup Bias-0.8
+kdma_values:
+- kdma: Moral judgement
+  value: 0.8
+- kdma: Ingroup Bias
+  value: 0.8

--- a/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Ingroup Bias-IO-high_MJ-low.yaml
+++ b/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Ingroup Bias-IO-high_MJ-low.yaml
@@ -1,0 +1,8 @@
+_target_: swagger_client.models.AlignmentTarget
+
+id: ADEPT-DryRun-Ingroup Bias-0.8
+kdma_values:
+- kdma: Moral judgement
+  value: 0.2
+- kdma: Ingroup Bias
+  value: 0.8

--- a/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Ingroup Bias-IO-low_MJ-high.yaml
+++ b/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Ingroup Bias-IO-low_MJ-high.yaml
@@ -1,0 +1,8 @@
+_target_: swagger_client.models.AlignmentTarget
+
+id: ADEPT-DryRun-Ingroup Bias-0.2
+kdma_values:
+- kdma: Moral judgement
+  value: 0.8
+- kdma: Ingroup Bias
+  value: 0.2

--- a/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Ingroup Bias-IO-low_MJ-low.yaml
+++ b/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Ingroup Bias-IO-low_MJ-low.yaml
@@ -1,0 +1,8 @@
+_target_: swagger_client.models.AlignmentTarget
+
+id: ADEPT-DryRun-Ingroup Bias-0.2
+kdma_values:
+- kdma: Moral judgement
+  value: 0.2
+- kdma: Ingroup Bias
+  value: 0.2

--- a/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Moral judgement-MJ-high_IO-high.yaml
+++ b/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Moral judgement-MJ-high_IO-high.yaml
@@ -1,0 +1,8 @@
+_target_: swagger_client.models.AlignmentTarget
+
+id: ADEPT-DryRun-Moral judgement-0.8
+kdma_values:
+- kdma: Moral judgement
+  value: 0.8
+- kdma: Ingroup Bias
+  value: 0.8

--- a/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Moral judgement-MJ-high_IO-low.yaml
+++ b/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Moral judgement-MJ-high_IO-low.yaml
@@ -1,0 +1,8 @@
+_target_: swagger_client.models.AlignmentTarget
+
+id: ADEPT-DryRun-Moral judgement-0.8
+kdma_values:
+- kdma: Moral judgement
+  value: 0.8
+- kdma: Ingroup Bias
+  value: 0.2

--- a/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Moral judgement-MJ-low-IO-high.yaml
+++ b/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Moral judgement-MJ-low-IO-high.yaml
@@ -1,0 +1,8 @@
+_target_: swagger_client.models.AlignmentTarget
+
+id: ADEPT-DryRun-Moral judgement-0.2
+kdma_values:
+- kdma: Moral judgement
+  value: 0.2
+- kdma: Ingroup Bias
+  value: 0.8

--- a/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Moral judgement-MJ-low-IO-low.yaml
+++ b/align_system/configs/alignment_target/multi_target/ADEPT-DryRun-Moral judgement-MJ-low-IO-low.yaml
@@ -1,0 +1,8 @@
+_target_: swagger_client.models.AlignmentTarget
+
+id: ADEPT-DryRun-Moral judgement-0.2
+kdma_values:
+- kdma: Moral judgement
+  value: 0.2
+- kdma: Ingroup Bias
+  value: 0.2


### PR DESCRIPTION
Adds multi-kdma targets for testing

`Ingroup Bias-lowhigh` means IB is low and MJ is high whereas `Moral judgement-lowhigh` means MJ is low and IB is high, i.e the KDMA that will be scored by the TA1/3 server is listed first