### PR TITLE
Updating Kaleido Alignment Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Added multi-KDMA alignment function that weights distance by relevance
 * Added a relevance oracle ADM
 * Added an optional relevance prediction step with ICL to the comparative regression ADM
-* Added the option to use relevance weighted alignment function to Kaleido ADM
+* Added options to use cumulative KDE and/or relevance weighted alignment function to Kaleido ADM
 
 ### Changed
 

--- a/align_system/algorithms/kaleido_adm.py
+++ b/align_system/algorithms/kaleido_adm.py
@@ -482,6 +482,6 @@ class KaleidoADM(AlignedDecisionMaker, ActionBasedADM):
 
         choice_info = {'true_kdma_values': true_kdma_values,
                        'predicted_kdma_values': predicted_kdma_values,
-                       'true_relevances': true_relevances,
-                       'predicted_relevances': predicted_relevances}
+                       'true_relevance': true_relevances,
+                       'predicted_relevance': predicted_relevances}
         return action_to_take, choice_info

--- a/align_system/algorithms/kaleido_adm.py
+++ b/align_system/algorithms/kaleido_adm.py
@@ -218,8 +218,7 @@ class KaleidoADM(AlignedDecisionMaker, ActionBasedADM):
             kdma_values.setdefault(choice, {})[kdma] =\
                 [float(v) for v in (group_records['estimated_kdma_value'] / 10)]
 
-            relevance_values.setdefault(choice, {})[kdma] =\
-                [float(v) for v in (group_records['relevant'])]
+            relevance_values.setdefault(choice, {})[kdma] = float(group_records['relevant'])
 
         if predict_relevance:
             selected_choice, probs = alignment_fn(kdma_values, relevance_values, target_kdmas)

--- a/align_system/configs/experiment/phase1_evaluation/hybrid_kaleido_soartech_train.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/hybrid_kaleido_soartech_train.yaml
@@ -1,0 +1,18 @@
+# @package _global_
+defaults:
+  - override /adm: hybrid_kaleido
+  - override /interface: ta3
+
+adm:
+  inference_kwargs:
+    kdma_descriptions_map: 'align_system/prompt_engineering/kdma_descriptions.yml'
+    distribution_matching: cumulative_kde 
+    kde_norm: priornorm
+    priornorm_factor: 0.5 
+
+interface:
+  api_endpoint: "http://127.0.0.1:8089"
+  session_type: soartech
+  training_session: full
+
+align_to_target: true

--- a/align_system/configs/experiment/phase1_evaluation/relevance_hybrid_kaleido_soartech_train.yaml
+++ b/align_system/configs/experiment/phase1_evaluation/relevance_hybrid_kaleido_soartech_train.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+defaults:
+  - override /adm: hybrid_kaleido
+  - override /interface: ta3
+
+adm:
+  inference_kwargs:
+    kdma_descriptions_map: 'align_system/prompt_engineering/kdma_descriptions.yml'
+    distribution_matching: relevance_cumulative_kde 
+    kde_norm: priornorm
+    priornorm_factor: 0.5 
+    predict_relevance: true
+
+interface:
+  api_endpoint: "http://127.0.0.1:8089"
+  session_type: soartech
+  training_session: full
+
+align_to_target: true

--- a/align_system/utils/alignment_utils.py
+++ b/align_system/utils/alignment_utils.py
@@ -137,7 +137,7 @@ class AvgDistScalarAlignment(AlignmentFunction):
 
 
 class CumulativeAvgDistScalarAlignment(AlignmentFunction):
-    def __call__(self, kdma_values, target_kdmas, choice_history, misaligned=False, kde_norm='globalnorm', probabilistic=False):
+    def __call__(self, kdma_values, target_kdmas, choice_history={}, misaligned=False, kde_norm='globalnorm', probabilistic=False):
         '''
         Uses choice history to calcualte a running average,
         selects the choice that brings the running average closeest to the scalar target.

--- a/align_system/utils/alignment_utils.py
+++ b/align_system/utils/alignment_utils.py
@@ -137,13 +137,16 @@ class AvgDistScalarAlignment(AlignmentFunction):
 
 
 class CumulativeAvgDistScalarAlignment(AlignmentFunction):
-    def __call__(self, kdma_values, target_kdmas, choice_history={}, misaligned=False, kde_norm='globalnorm', probabilistic=False):
+    def __call__(self, kdma_values, target_kdmas, choice_history=None, misaligned=False, kde_norm='globalnorm', probabilistic=False):
         '''
         Uses choice history to calcualte a running average,
         selects the choice that brings the running average closeest to the scalar target.
         '''
         kdma_values = _handle_single_value(kdma_values, target_kdmas)
         _check_if_targets_are_scalar(target_kdmas)
+
+        if choice_history is None:
+            choice_history = {}
 
         # Get distance from running average to targets
         distances = []
@@ -441,7 +444,7 @@ class RelevanceAvgDistScalarAlignment(RelevanceAlignmentFunction):
                 average_score = (sum(score_samples) / len(score_samples))
                 relevance = relevances[choice][kdma]
                 distance = _euclidean_distance(target_kdma['value'], average_score)
-                prob += relevance * (1/(distance+eps)) # weight by relevance 
+                prob += relevance * (1/(distance+eps)) # weight by relevance
             probs.append(prob)
         selected_choice, probs = self._select_min_dist_choice(choices, probs, misaligned, probabilistic=probabilistic)
         return selected_choice, probs


### PR DESCRIPTION
Adds the option to use cumulative KDE alignment with Kaleido, either with or without relevance.
- This config runs cumulative KDE alignment without relevance: `align_system/configs/experiment/phase1_evaluation/hybrid_kaleido_soartech_train.yaml`
- This config runs with relevance: `align_system/configs/experiment/phase1_evaluation/relevance_hybrid_kaleido_soartech_train.yaml`