### PR TITLE
Log true relevance for comp regression

### DIFF
--- a/align_system/algorithms/outlines_regression_adm_comparative.py
+++ b/align_system/algorithms/outlines_regression_adm_comparative.py
@@ -466,6 +466,17 @@ class OutlinesTransformersComparativeRegressionADM(OutlinesTransformersADM):
         choice_info = {'true_kdma_values':true_kdma_values, 'predicted_kdma_values':predicted_kdma_values, 'icl_example_responses':icl_example_responses}
 
         if predict_relevance:
+            # Log true relevance if present
+            true_relevance = {}
+            for choice_idx in range(len(available_actions)):
+                true_relevance[choices[choice_idx]] = {
+                    kdma['kdma']: 1 if available_actions[choice_idx].kdma_association is not None and kdma['kdma'] in available_actions[choice_idx].kdma_association else 0
+                    for kdma in target_kdmas
+                }
+            log.info("True Relevance")
+            log.info(json.dumps(true_relevance))
+            choice_info['true_relevance'] = true_relevance
+
             # Log predicted relevance
             log.info("Predicted Relevance Values:")
             log.info(json.dumps(predicted_relevance))

--- a/align_system/utils/incontext_utils.py
+++ b/align_system/utils/incontext_utils.py
@@ -569,7 +569,7 @@ class RelevanceIncontextExampleGenerator(IncontextExampleGenerator):
                             icl_response[choice]['reasoning'] = self.get_irrelevant_chain_of_thought_reasoning(target_kdma, choice)
                         # else add generic COT reasoning
                         else:
-                            icl_response[choice]['reasoning'] = f'Selecting this response does not require considering {target_kdma['name']}.'
+                            icl_response[choice]['reasoning'] = f'Selecting this response does not require considering {target_kdma["name"]}.'
                         icl_response[choice]['relevant'] = 'no'
                     included_choices.append(choice)
                 # Check if response is valid against json schema
@@ -653,4 +653,3 @@ class RelevanceIncontextExampleGenerator(IncontextExampleGenerator):
             raise RuntimeError(f"Relevance ICL is not implemented for {target_kdma['kdma']}")
 
         return cot_reasoning
-


### PR DESCRIPTION
Adds true relevance values to the input output file for the comparative regression ADM. I don't think this is worthy of a changelog entry, but let me know if you'd like me to add one