### PR TITLE
Add config for naacl24 kaleido runs

### DIFF
--- a/align_system/algorithms/lib/templates/kdma_descriptions_short_naacl24_paper.yml
+++ b/align_system/algorithms/lib/templates/kdma_descriptions_short_naacl24_paper.yml
@@ -1,0 +1,29 @@
+MoralDesert:
+  name: moral desert
+  description: Favoring victims or bystanders over those who are perpetrators or otherwise potentially blame-worthy
+  vrd: Value
+
+ContinuationOfCare:
+  name: continuation of care
+  description: Duty to continue treating the current casualty
+  vrd: Duty
+
+RiskAversion:
+  name: risk aversion
+  description: Avoiding risky or uncertain actions
+  vrd: Value
+
+Fairness:
+  name: fairness
+  description: Right to fair treatment
+  vrd: Right
+
+ProtocolFocus:
+  name: protocol focus
+  description: Following the protocol, guidelines, or rules
+  vrd: Value
+
+Utilitarianism:
+  name: utilitarianism
+  description: Duty to provide the best medical outcome for the most people
+  vrd: Duty

--- a/align_system/configs/experiment/demo/kaleido_adm_naacl24.yaml
+++ b/align_system/configs/experiment/demo/kaleido_adm_naacl24.yaml
@@ -1,0 +1,24 @@
+# @package _global_
+defaults:
+  - override /adm: hybrid_kaleido
+  - override /interface: input_output_file
+
+interface:
+  input_output_filepath: 'example_data/input_output_files/NAACL24_dataset_split/oracle_continuing_care_training_input_output.json'
+  # possible input-output json filepaths
+  # 'example_data/input_output_files/NAACL24_dataset_split/oracle_fairness_training_input_output.json'
+  # 'example_data/input_output_files/NAACL24_dataset_split/oracle_moral_desert_training_input_output.json'
+  # 'example_data/input_output_files/NAACL24_dataset_split/oracle_protocol_focus_training_input_output.json'
+  # 'example_data/input_output_files/NAACL24_dataset_split/oracle_risk_aversion_training_input_output.json'
+  # 'example_data/input_output_files/NAACL24_dataset_split/oracle_utilitarianism_training_input_output.json'
+adm:
+  instance:
+    kaleido_adm:
+      model_name: 'allenai/kaleido-large'
+
+  inference_kwargs:
+    kdma_descriptions_map: 'align_system/algorithms/lib/templates/kdma_descriptions_short_naacl24_paper.yml'
+
+force_determinism: true
+align_to_target: true
+save_last_unstructured_state_per_scenario: true


### PR DESCRIPTION
@barry-ravichandran here's the few tweaks needed to get Kaleido up and running on the NAACL24 data.

Note that I'm using short descriptions of the KDMAs (rather than the longer descriptions specified in the other naacl24 KDMA descriptions file you added) I believe way back at the time of the NAACL24 paper I had tried both long and short versions, and these shorter versions worked a little better.