### PR TITLE
Fix dataset validation errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requests = "^2.31.0"
 bert-score = "^0.3.13"
 rich = "^13.6.0"
 rouge-score = "^0.1.2"
-swagger-client = {git = "https://github.com/NextCenturyCorporation/itm-evaluation-client.git", rev = "development"}
+swagger-client = {git = "https://github.com/NextCenturyCorporation/itm-evaluation-client.git", rev = "0.4.0"}
 hydra-core = "^1.3.2"
 outlines = "^0.0.46"
 setuptools = "^70.1.1"


### PR DESCRIPTION
By pinning commit SHA of itm-evaluation-client, aka swagger-client.

There is a bug due to upstream itm-evaluation-client changes.  Steps

```
python3 -m venv .venv
source .venv/bin/activate
pip install -e .
run_align_system
```

Get error
```
Error executing job with overrides: []
Error in call to target 'align_system.interfaces.input_output_file.InputOutputFileInterface':
TypeError('swagger_client.models.meta_info.MetaInfo() argument after ** must be a mapping, not MetaInfo')
full_key: interface
```
