### PR TITLE
Determinism Fixes for Baseline ADM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 This changelog follows the specifications detailed in: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), although we have not yet reached a `1.0.0` release.
 
+## Unreleased
+
+### Fixed
+
+* Fixed non-determinism issues with outlines_adm baseline with shuffle_choices arg and outlines seed
+
+### Added
+
+* Added shuffle_choices inference_kwarg argument for outlines_adm baseline
+* Added option to set outlines RNG seed for outlines_adm
+
 ## 0.5.7
 
 ### Fixed


### PR DESCRIPTION
Obvious in hindsight, it seems like the baseline shuffles the choices by default which will certainly cause some non-determinism.  I also added support in the outlines ADM for setting the outlines seed (which shouldn't affect things when using the Greedy sampler, but would allow you to get deterministic results with the multinomial sampler).