### PR TITLE
Updating zeroshot ADM to run on server

### DIFF
--- a/align_system/configs/adm/phase2_pipeline_zeroshot_comparative_regression.yaml
+++ b/align_system/configs/adm/phase2_pipeline_zeroshot_comparative_regression.yaml
@@ -20,7 +20,6 @@ defaults:
   - /adm_component/misc@step_definitions.regression_rule_based_correction: phase2_regression_rule_based_correction
   - /adm_component/alignment@step_definitions.scalar_alignment: medical_urgency_scalar
   - /adm_component/misc@step_definitions.justification_from_reasonings: justification_from_reasonings
-  - /adm_component/misc@step_definitions.action_parameter_completion: action_parameter_completion
   - /adm_component/misc@step_definitions.ensure_chosen_action: ensure_chosen_action
   - /adm_component/misc@step_definitions.populate_choice_info: populate_choice_info
   # Use definitions in this file to override defaults defined above
@@ -49,6 +48,5 @@ instance:
     - ${ref:adm.step_definitions.regression_rule_based_correction}
     - ${ref:adm.step_definitions.scalar_alignment}
     - ${ref:adm.step_definitions.justification_from_reasonings}
-    - ${ref:adm.step_definitions.action_parameter_completion}
     - ${ref:adm.step_definitions.ensure_chosen_action}
     - ${ref:adm.step_definitions.populate_choice_info}

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_zeroshot_comparative_regression.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_zeroshot_comparative_regression.yaml
@@ -1,26 +1,14 @@
 # @package _global_
 defaults:
-  - /attribute@adm.personal_safety: personal_safety
-  - /attribute@adm.search_or_stay: search_or_stay
   - override /adm: phase2_pipeline_zeroshot_comparative_regression
-  - override /interface: input_output_file
+  - override /interface: ta3
 
-adm:
-  step_definitions:
-    kaleido:
-      kdma_descriptions_map:
-        Personal Safety:
-          name: Personal Safety
-          description: Tendency to hold back from moving to treat a patient when that requires risking exposure to enemy fire, waiting rather than immediately moving to treat the patient
-          vrd: Value
-        Search or Stay:
-          name: Search or Stay
-          description: Tendency to move on from their current patient in order to treat or search for another patient
-          vrd: Value
-  
-  attribute_definitions:
-    Personal Safety: ${adm.personal_safety}
-    Search or Stay: ${adm.search_or_stay}
-    
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_zeroshot_comp_reg_test"
+  domain: "p2triage"
+
+apply_action_filtering: false
 force_determinism: true
 align_to_target: true


### PR DESCRIPTION
- Updates the experiment yaml to run on server rather than input_output
- Updates the zeroshot comparative regression pipeline ADM to skip the action parameter completion step as it is no longer needed