### PR TITLE
Adding phase2 pipeline oracle adm

### DIFF
--- a/align_system/algorithms/misc_itm_adm_components.py
+++ b/align_system/algorithms/misc_itm_adm_components.py
@@ -136,3 +136,29 @@ class Phase2RegressionRuleBasedCorrection(ADMComponent):
         log.info("Corrected:{}".format(attribute_prediction_scores), extra={"highlighter": JSON_HIGHLIGHTER})
 
         return attribute_prediction_scores
+
+
+class OracleRegression(ADMComponent):
+    def run_returns(self):
+        return 'attribute_prediction_scores'
+
+    def run(self,
+            actions):
+        # Returns ground truth `attribute_prediction_scores`
+        attribute_prediction_scores = {}
+        for action in actions:
+            if hasattr(action, 'kdma_association') and action.kdma_association is not None:
+                attribute_prediction_scores[action.unstructured] = action.kdma_association.copy()
+
+        log.info("[bold]*GROUND TRUTH KDMA SCORES*[/bold]", extra={"markup": True})
+        log.info("{}".format(attribute_prediction_scores), extra={"highlighter": JSON_HIGHLIGHTER})
+
+        return attribute_prediction_scores
+
+
+class OracleJustification(ADMComponent):
+    def run_returns(self):
+        return 'justification'
+
+    def run(self):
+        return "Looked at scores."

--- a/align_system/configs/adm/phase2_pipeline_oracle.yaml
+++ b/align_system/configs/adm/phase2_pipeline_oracle.yaml
@@ -1,0 +1,38 @@
+name: phase2_pipeline_oracle
+
+defaults:
+  # Import defaults into this namspace (adm) as @name, for further
+  # customization
+  - /attribute@mu: medical_urgency
+  - /attribute@af: affiliation_focus
+  - /attribute@mf: merit_focus
+  - /attribute@ss: search_or_stay
+  - /attribute@ps: personal_safety
+  # Shared variables / components
+  - /adm_component/misc@step_definitions.format_choices: itm_format_choices
+  - /adm_component/misc@step_definitions.oracle_regression: oracle_regression
+  - /adm_component/alignment@step_definitions.scalar_alignment: medical_urgency_scalar
+  - /adm_component/misc@step_definitions.oracle_justification: oracle_justification
+  - /adm_component/misc@step_definitions.ensure_chosen_action: ensure_chosen_action
+  - /adm_component/misc@step_definitions.populate_choice_info: populate_choice_info
+  # Use definitions in this file to override defaults defined above
+  - _self_
+
+attribute_definitions:
+  medical: ${adm.mu}
+  affiliation: ${adm.af}
+  merit: ${adm.mf}
+  search: ${adm.ss}
+  personal_safety: ${adm.ps}
+
+instance:
+  _target_: align_system.algorithms.pipeline_adm.PipelineADM
+
+  steps:
+    # Reference the step instances we want to use in order
+    - ${ref:adm.step_definitions.format_choices}
+    - ${ref:adm.step_definitions.oracle_regression}
+    - ${ref:adm.step_definitions.scalar_alignment}
+    - ${ref:adm.step_definitions.oracle_justification}
+    - ${ref:adm.step_definitions.ensure_chosen_action}
+    - ${ref:adm.step_definitions.populate_choice_info}

--- a/align_system/configs/adm_component/misc/oracle_justification.yaml
+++ b/align_system/configs/adm_component/misc/oracle_justification.yaml
@@ -1,0 +1,1 @@
+_target_: align_system.algorithms.misc_itm_adm_components.OracleJustification

--- a/align_system/configs/adm_component/misc/oracle_regression.yaml
+++ b/align_system/configs/adm_component/misc/oracle_regression.yaml
@@ -1,0 +1,1 @@
+_target_: align_system.algorithms.misc_itm_adm_components.OracleRegression

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_oracle.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_oracle.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_oracle
+  - override /interface: ta3
+
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_oracle_test"
+  domain: "p2triage"
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true


### PR DESCRIPTION
Adds phase2 pipeline oracle ADM which uses ground truth scores as regressed values and `medical_urgency_scalar` alignment.
Example command to run:
```
run_align_system +experiment=phase2_june_collab/pipeline_oracle interface.scenario_ids=[June2025-AF-train] +alignment_target=june2025/ADEPT-June2025-affiliation-1.0
```