### PR TITLE
Phase2 fewshot ADM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 This changelog follows the specifications detailed in: [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html), although we have not yet reached a `1.0.0` release.
 
+## Unreleased
+
+### Added
+
+* Added `state_hydration_domain` to `IncontextExampleGenerator` and `InputOutputFileInterface`. Providing a value of
+  `None` or `p1` results in Phase 1 behavior while a value of `p2triage` is meant for hydrating states from the
+  corresponding domain on the TA3 server.
+
 ## 0.5.8
 
 ### Fixed

--- a/align_system/algorithms/comparative_regression_adm_component.py
+++ b/align_system/algorithms/comparative_regression_adm_component.py
@@ -79,8 +79,9 @@ class ComparativeRegressionADMComponent(ADMComponent):
             # If we get icl_dialog_elements, include them in the
             # dialog, maybe a more explicit argument (wether or not to
             # use icl) makes more sense?
-            if len(icl_dialog_elements) > 0:
-                dialog.extend(icl_dialog_elements)
+            if icl_dialog_elements:
+                if len(icl_dialog_elements[attribute.kdma]) > 0:
+                    dialog.extend(icl_dialog_elements[attribute.kdma])
 
             predict_kdma_prompt = call_with_coerced_args(
                 self.prompt_template,

--- a/align_system/configs/adm/phase2_pipeline_fewshot_comparative_regression.yaml
+++ b/align_system/configs/adm/phase2_pipeline_fewshot_comparative_regression.yaml
@@ -1,0 +1,59 @@
+name: phase2_pipeline_zeroshot_comparative_regression
+
+defaults:
+  # Import defaults into this namspace (adm) as @name, for further
+  # customization
+
+  # Shared variables / components
+  - /attribute@mu: medical_urgency
+  - /attribute@af: affiliation_focus
+  - /attribute@mf: merit_focus
+  - /attribute@ss: search_or_stay
+  - /attribute@ps: personal_safety
+  - /inference_engine@structured_inference_engine: outlines_structured_greedy
+  - /template/scenario_description@scenario_description_template: phase2
+  - /template/prompt@prompt_template: phase2_comparative_regression
+  - /template/output_schema@comparative_regression_choice_schema: phase2_comparative_regression_choice
+  # ADM components to be used in "steps"
+  - /adm_component/misc@step_definitions.format_choices: itm_format_choices
+  - /adm_component/icl@step_definitions.regression_icl: phase2_comparative
+  - /adm_component/regression@step_definitions.comparative_regression: phase2_comparative_no_template
+  - /adm_component/misc@step_definitions.regression_rule_based_correction: phase2_regression_rule_based_correction
+  - /adm_component/alignment@step_definitions.scalar_alignment: medical_urgency_scalar
+  - /adm_component/misc@step_definitions.justification_from_reasonings: justification_from_reasonings
+  - /adm_component/misc@step_definitions.ensure_chosen_action: ensure_chosen_action
+  - /adm_component/misc@step_definitions.populate_choice_info: populate_choice_info
+  # Use definitions in this file to override defaults defined above
+  - _self_
+
+attribute_definitions:
+  medical: ${adm.mu}
+  affiliation: ${adm.af}
+  merit: ${adm.mf}
+  search: ${adm.ss}
+  personal_safety: ${adm.ps}
+
+step_definitions:
+  regression_icl:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    attributes: ${adm.attribute_definitions}
+    prompt_template: ${ref:adm.prompt_template}
+
+  comparative_regression:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    prompt_template: ${ref:adm.prompt_template}
+    score_schema_template: ${adm.comparative_regression_choice_schema}
+
+instance:
+  _target_: align_system.algorithms.pipeline_adm.PipelineADM
+
+  steps:
+    # Reference the step instances we want to use in order
+    - ${ref:adm.step_definitions.format_choices}
+    - ${ref:adm.step_definitions.regression_icl}
+    - ${ref:adm.step_definitions.comparative_regression}
+    - ${ref:adm.step_definitions.regression_rule_based_correction}
+    - ${ref:adm.step_definitions.scalar_alignment}
+    - ${ref:adm.step_definitions.justification_from_reasonings}
+    - ${ref:adm.step_definitions.ensure_chosen_action}
+    - ${ref:adm.step_definitions.populate_choice_info}

--- a/align_system/configs/adm_component/icl/phase2_comparative.yaml
+++ b/align_system/configs/adm_component/icl/phase2_comparative.yaml
@@ -16,5 +16,8 @@ icl_generator_partial:
     sort_actions: true
     most_similar_first: false
     datasets:
-      medical: /data/shared/samba/phase2_icl/June2025-AF-train_20250523.json
+      medical: /data/shared/samba/phase2_icl/June2025-MU-train_20250523.json
       affiliation: /data/shared/samba/phase2_icl/June2025-AF-train_20250523.json
+      merit: /data/shared/samba/phase2_icl/June2025-MF-train_20250523.json
+      personal_safety: /data/shared/samba/phase2_icl/June2025-PS-train_20250523.json
+      search: /data/shared/samba/phase2_icl/June2025-SS-train_20250523.json

--- a/align_system/configs/adm_component/icl/phase2_comparative.yaml
+++ b/align_system/configs/adm_component/icl/phase2_comparative.yaml
@@ -21,3 +21,5 @@ icl_generator_partial:
       merit: /data/shared/samba/phase2_icl/June2025-MF-train_20250523.json
       personal_safety: /data/shared/samba/phase2_icl/June2025-PS-train_20250523.json
       search: /data/shared/samba/phase2_icl/June2025-SS-train_20250523.json
+
+  state_hydration_domain: p2triage

--- a/align_system/configs/adm_component/icl/phase2_comparative.yaml
+++ b/align_system/configs/adm_component/icl/phase2_comparative.yaml
@@ -1,0 +1,20 @@
+_target_: align_system.algorithms.icl_adm_component.ICLADMComponent
+
+predict_medical_urgency: true
+
+icl_generator_partial:
+  _target_: align_system.utils.incontext_utils.Phase2ComparativeRegressionIncontextExampleGenerator
+  # Partially initialize so we can finish initialization with multiple
+  # alignment targets
+  _partial_: true
+
+  incontext_settings:
+    number: 5
+    method: prompt_bert_similarity
+    leave_one_out_strategy: null
+    normalization: null
+    sort_actions: true
+    most_similar_first: false
+    datasets:
+      medical: /data/shared/samba/phase2_icl/June2025-AF-train_20250523.json
+      affiliation: /data/shared/samba/phase2_icl/June2025-AF-train_20250523.json

--- a/align_system/configs/adm_component/regression/phase2_comparative_no_template.yaml
+++ b/align_system/configs/adm_component/regression/phase2_comparative_no_template.yaml
@@ -1,0 +1,8 @@
+_target_: align_system.algorithms.comparative_regression_adm_component.ComparativeRegressionADMComponent
+
+structured_inference_engine: ${ref:adm.structured_inference_engine}
+num_samples: 1
+predict_medical_urgency: True
+attributes: ${ref:adm.attribute_definitions}
+system_prompt_template:
+  _target_: align_system.prompt_engineering.outlines_prompts.ComparativeRegressionSystemPrompt

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo.yaml
@@ -1,0 +1,22 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+    
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_fewshot_comp_reg_test"
+  domain: "p2triage"
+
+# LOO - Remove for eval
+adm:
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          leave_one_out_strategy: 'scenario_description'
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true

--- a/align_system/prompt_engineering/outlines_prompts.py
+++ b/align_system/prompt_engineering/outlines_prompts.py
@@ -1224,6 +1224,36 @@ class Phase2BaselinePrompt():
         return phase2_baseline_prompt(scenario_description, choices)
 
 
+def comparative_regression_system_prompt(
+    kdma, kdma_description, kdma_scale_factor
+):
+    """
+    You are a specialized algorithm tasked with assessing medical triage decisions \
+    in a military medical context.  Given a scenario and list of possible responses, \
+    your job is to assess (on a scale from 0 to {{kdma_scale_factor}}) the degree of \
+    {{kdma}} associated with each response.
+
+    {{kdma_description}}
+
+    Provide a statement of reasoning and then a score for each response.
+    """
+
+
+class ComparativeRegressionSystemPrompt():
+    def __init__(self):
+        self.environment = jinja2.Environment()
+
+    def __call__(self, target_attribute):
+        template = self.environment.from_string(
+            target_attribute.score_examples)
+        score_examples = template.render(
+            kdma_scale_factor=target_attribute.factor)
+        return comparative_regression_system_prompt(
+            target_attribute.name,
+            target_attribute.description,
+            target_attribute.factor)
+
+
 @outlines.prompt
 def comparative_regression_system_prompt_with_examples(
     kdma, kdma_description, kdma_score_examples, kdma_scale_factor

--- a/align_system/prompt_engineering/outlines_prompts.py
+++ b/align_system/prompt_engineering/outlines_prompts.py
@@ -1224,6 +1224,7 @@ class Phase2BaselinePrompt():
         return phase2_baseline_prompt(scenario_description, choices)
 
 
+@outlines.prompt
 def comparative_regression_system_prompt(
     kdma, kdma_description, kdma_scale_factor
 ):

--- a/align_system/utils/hydrate_state.py
+++ b/align_system/utils/hydrate_state.py
@@ -1,19 +1,18 @@
-from swagger_client.models import (
-    State,
-    Action,
-    Character,
-    Supplies,
-    Injury,
-    Environment,
-    DecisionEnvironment,
-    Aid,
-    SimEnvironment,
-    MetaInfo,
-)
-
-
 def hydrate_scenario_state(record):
-    """ Hydrate scenario state from record """
+    """ Hydrate scenario state from p1 record """
+    from swagger_client.models import (
+        State,
+        Action,
+        Character,
+        Supplies,
+        Injury,
+        Environment,
+        DecisionEnvironment,
+        Aid,
+        SimEnvironment,
+        MetaInfo,
+    )
+
     state = State(**record['full_state'])
     state.meta_info = MetaInfo(**state.meta_info)
     # For some reason this initialization from a dictionary
@@ -30,6 +29,24 @@ def hydrate_scenario_state(record):
             Aid(**a) for a in state.environment.decision_environment.aid]
     state.environment.sim_environment = SimEnvironment(
         **state.environment.sim_environment)
+
+    actions = [Action(**a) for a in record['choices']]
+    # TODO: Fix this on the input-output generation side, need
+    # to make sure original choices aren't being modified by
+    # ADM; for now manually clearing the justification string
+    for a in actions:
+        a.justification = None
+
+    return state, actions
+
+def p2triage_hydrate_scenario_state(record):
+    """ Hydrate scenario state from p2triage record """
+    from swagger_client.models import (
+        State,
+        Action,
+    )
+
+    state = State(**record['full_state'])
 
     actions = [Action(**a) for a in record['choices']]
     # TODO: Fix this on the input-output generation side, need

--- a/align_system/utils/incontext_utils.py
+++ b/align_system/utils/incontext_utils.py
@@ -17,7 +17,10 @@ from align_system.prompt_engineering.outlines_prompts import (
     comparative_kdma_score_prediction_prompt,
     comparative_kdma_score_prediction_json_schema,
     relevance_classification_prompt,
-    relevance_classification_json_schema
+    relevance_classification_json_schema,
+    phase2_scenario_state_description,
+    comparative_regression_prompt,
+    comparative_regression_json_schema
 )
 
 
@@ -658,4 +661,83 @@ class RelevanceIncontextExampleGenerator(IncontextExampleGenerator):
         else:
             raise RuntimeError(f"Relevance ICL is not implemented for {target_kdma['kdma']}")
 
+        return cot_reasoning
+
+
+class Phase2ComparativeRegressionIncontextExampleGenerator(IncontextExampleGenerator):
+    def set_icl_datasets(self):
+        icl_datasets = {}
+        incontext_data = self._read_icl_dataset_files()
+
+        # Add each target to icl_datasets
+        for target_kdma in self.target_kdmas:
+            sys_kdma_name = target_kdma['kdma']
+            icl_datasets[sys_kdma_name] = []
+            kdma_incontext_data = incontext_data[sys_kdma_name]
+
+            # Add each examples to icl_datasets
+            for example in kdma_incontext_data:
+
+                # Get example response
+                icl_response = {}
+                included_choices = []
+                for action, choice, kdma_value in zip(example['actions'], example['choices'], example["kdma_values"]):
+                    # Only include choice if there is a ground truth KDMA value available
+                    if kdma_value is None:
+                        continue
+                    # Groundtruth KDMA values are 0-1, but ADM may predict on a different scale
+                    scaled_kdma_value = int(kdma_value * target_kdma["factor"])
+                    icl_response[choice] = {}
+                    icl_response[choice]['score'] = scaled_kdma_value
+                    included_choices.append(choice)
+                icl_response_with_reasoning={}
+                icl_response_with_reasoning['reasoning'] = self.get_chain_of_thought_reasoning(target_kdma, icl_response)
+                icl_response_with_reasoning.update(icl_response) # reasoning first
+                # Check if response is valid against json schema
+                correct_schema = json.loads(comparative_regression_json_schema(included_choices, target_kdma["factor"]))
+                validate(instance=icl_response_with_reasoning, schema=correct_schema)
+
+                # Get example prompt
+                icl_scenario_description = phase2_scenario_state_description(example['state'])
+                # Only include choices in the prompt if they are in the response
+                included_icl_choices_with_outcomes = {}
+                for choice in included_choices:
+                    # TODO: Include outcome prediction for ICL examples?
+                    included_icl_choices_with_outcomes[choice] = {'predicted_outcome':None}
+                icl_prompt = comparative_regression_prompt(icl_scenario_description,
+                                                           included_icl_choices_with_outcomes,
+                                                           target_kdma['name'])
+
+                # Add example
+                icl_datasets[sys_kdma_name].append({
+                    "state": example["state"],
+                    "scenario_description": icl_scenario_description,
+                    "prompt": icl_prompt,
+                    "response": icl_response_with_reasoning,
+                    "actions": example['actions']
+                    })
+
+        self.icl_datasets = icl_datasets
+
+    def get_chain_of_thought_reasoning(self, target_kdma, scores):
+        '''
+        Helper function for set_icl_datasets() - constructs example reasoning statements for responses
+        Assumes only two choices
+        '''
+        choices = list(scores.keys())
+        if scores[choices[0]]['score'] >= scores[choices[1]]['score']:
+            max_choice = choices[0]
+            min_choice = choices[1]
+        else:
+            max_choice = choices[1]
+            min_choice = choices[0]
+
+        diff = abs(scores[choices[0]]['score'] - scores[choices[1]]['score'])
+        adjective = ''
+        if diff >= 75:
+            adjective = 'much'
+        elif diff <= 25:
+            adjective = 'slightly'
+
+        cot_reasoning = f"{max_choice} demonstates {adjective} more {target_kdma['name']} than {min_choice}."
         return cot_reasoning


### PR DESCRIPTION
Adding phase2 fewshot ADM.
Example call to run:
```
run_align_system +experiment=phase2_june_collab/pipeline_fewshot_comparative_regression_loo interface.scenario_ids=[June2025-AF-train] +alignment_target=june2025/ADEPT-June2025-affiliation-1.0
```
Currently to run this I have to comment out lines 4-11 and 18-32 in `align_system/utils/hydrate_state.py` will look into a better solution before merging. 