### PR TITLE
Adding llm-based most relevant attribute prediction step

### DIFF
--- a/align_system/algorithms/misc_itm_adm_components.py
+++ b/align_system/algorithms/misc_itm_adm_components.py
@@ -74,7 +74,7 @@ class PopulateChoiceInfo(ADMComponent):
             actions,
             alignment_target=None,
             attribute_prediction_scores=None,
-            attribute_relevance_binary=None):
+            attribute_relevance=None):
         choice_info = {}
 
         if alignment_target is None:
@@ -85,17 +85,16 @@ class PopulateChoiceInfo(ADMComponent):
         if attribute_prediction_scores is not None:
             choice_info['predicted_kdma_values'] = attribute_prediction_scores
 
-        if attribute_relevance_binary is not None:
-            choice_info['predicted_relevance'] = attribute_relevance_binary
+        if attribute_relevance is not None:
+            choice_info['predicted_relevance'] = attribute_relevance
 
         true_kdma_values = {}
         true_relevance = {}
         for choice, action in zip(choices, actions):
             if action.kdma_association is not None:
                 true_kdma_values[choice] = action.kdma_association
-
                 for kdma in target_kdmas:
-                    true_relevance[choice] = 1 if kdma in action.kdma_association else 0
+                    true_relevance[kdma] = 1 if kdma in action.kdma_association else 0
 
         if len(true_kdma_values) > 0:
             choice_info['true_kdma_values'] = true_kdma_values

--- a/align_system/algorithms/relevance_adm_component.py
+++ b/align_system/algorithms/relevance_adm_component.py
@@ -1,0 +1,115 @@
+from rich.highlighter import JSONHighlighter
+
+from align_system.utils import logging, call_with_coerced_args
+from align_system.algorithms.abstracts import ADMComponent
+from align_system.utils.alignment_utils import attributes_in_alignment_target
+from align_system.data_models.dialog import DialogElement
+
+log = logging.getLogger(__name__)
+JSON_HIGHLIGHTER = JSONHighlighter()
+
+
+class PredictMostRelevantADMComponent(ADMComponent):
+    def __init__(self,
+                 structured_inference_engine,
+                 scenario_description_template,
+                 prompt_template,
+                 relevance_schema_template,
+                 attributes={},
+                 system_prompt_template=None,
+                 num_samples=1,
+                 enum_scores=False):
+        self.structured_inference_engine = structured_inference_engine
+        self.scenario_description_template = scenario_description_template
+        self.prompt_template = prompt_template
+        self.relevance_schema_template = relevance_schema_template
+
+        self.attributes = attributes
+
+        self.system_prompt_template = system_prompt_template
+
+        self.num_samples = num_samples
+        self.enum_scores = enum_scores
+
+    def run_returns(self):
+        return ('attribute_relevance',
+                'attribute_dialogs')
+
+    def run(self,
+            scenario_state,
+            choices,
+            # icl_dialog_elements=[],
+            alignment_target=None):
+        if alignment_target is None:
+            target_attribute_names = []
+        else:
+            target_attribute_names = attributes_in_alignment_target(alignment_target)
+
+        target_attributes = [self.attributes[n] for n in target_attribute_names]
+        attribute_names = [attribute.name for attribute in target_attributes]
+
+        attribute_dialogs = {}
+        scenario_description = call_with_coerced_args(
+            self.scenario_description_template,
+            {'scenario_state': scenario_state})
+
+        dialog = []
+        if self.system_prompt_template is not None:
+            system_prompt = call_with_coerced_args(
+                self.system_prompt_template,
+                {'target_attributes': target_attributes})
+
+            dialog.insert(0, DialogElement(role='system',
+                                            content=system_prompt,
+                                            namespace='.',
+                                            tags=['relevance']))
+
+        # # If we get icl_dialog_elements, include them in the
+        # # dialog, maybe a more explicit argument (wether or not to
+        # # use icl) makes more sense?
+        # if len(icl_dialog_elements) > 0:
+        #     dialog.extend(icl_dialog_elements)
+
+        predict_most_relevant_prompt = call_with_coerced_args(
+            self.prompt_template,
+            {'scenario_state': scenario_state,
+                'scenario_description': scenario_description,
+                'choices': choices,
+                'attributes': target_attributes})
+
+        dialog.append(DialogElement(role='user',
+                                    content=predict_most_relevant_prompt,
+                                    namespace='.',
+                                    tags=['relevance']))
+
+        relevance_schema = call_with_coerced_args(
+            self.relevance_schema_template,
+            {'target_attribute_names': attribute_names})
+
+        dialog_prompt = self.structured_inference_engine.dialog_to_prompt(dialog)
+
+        log.info("[bold]*MOST RELEVANT ATTRIBUTE PREDICTION DIALOG PROMPT*[/bold]",
+                    extra={"markup": True})
+        log.info(dialog_prompt)
+
+        responses = self.structured_inference_engine.run_inference(
+                [dialog_prompt] * self.num_samples, relevance_schema)
+
+        # Use responses to define attribute relevance dictionary
+        attribute_relevance = {}
+        for target_attribute in target_attributes:
+            attribute_relevance[target_attribute.kdma] = []
+
+        for i, response in enumerate(responses):
+            log.info("[bold]*RELEVANCE PREDICTION RESPONSE (sample #{})*[/bold]".format(
+                i), extra={"markup": True})
+            log.info(response, extra={"highlighter": JSON_HIGHLIGHTER})
+
+            most_relevant = response['most_relevant']
+            for target_attribute in target_attributes:
+                if target_attribute.name == most_relevant:
+                    attribute_relevance[target_attribute.kdma].append(1)
+                else:
+                    attribute_relevance[target_attribute.kdma].append(0)
+        log.info("attribute_relevance: {}".format(attribute_relevance), extra={"highlighter": JSON_HIGHLIGHTER})
+        return attribute_relevance, attribute_dialogs

--- a/align_system/configs/adm/phase2_pipeline_fewshot_comparative_regression_predict_most_relevant.yaml
+++ b/align_system/configs/adm/phase2_pipeline_fewshot_comparative_regression_predict_most_relevant.yaml
@@ -1,0 +1,64 @@
+name: phase2_pipeline_zeroshot_comparative_regression
+
+defaults:
+  # Import defaults into this namspace (adm) as @name, for further
+  # customization
+
+  # Shared variables / components
+  - /attribute@mu: medical_urgency
+  - /attribute@af: affiliation_focus
+  - /attribute@mf: merit_focus
+  - /attribute@ss: search_or_stay
+  - /attribute@ps: personal_safety
+  - /inference_engine@structured_inference_engine: outlines_structured_greedy
+  - /template/scenario_description@scenario_description_template: phase2
+  - /template/prompt@prompt_template: phase2_comparative_regression
+  - /template/output_schema@comparative_regression_choice_schema: phase2_comparative_regression_choice
+  # ADM components to be used in "steps"
+  - /adm_component/misc@step_definitions.format_choices: itm_format_choices
+  - /adm_component/relevance@step_definitions.predict_most_relevant: predict_most_relevant
+  - /adm_component/icl@step_definitions.regression_icl: phase2_comparative
+  - /adm_component/regression@step_definitions.comparative_regression: phase2_comparative_no_template
+  - /adm_component/misc@step_definitions.regression_rule_based_correction: phase2_regression_rule_based_correction
+  - /adm_component/alignment@step_definitions.scalar_alignment: medical_urgency_scalar
+  - /adm_component/misc@step_definitions.justification_from_reasonings: justification_from_reasonings
+  - /adm_component/misc@step_definitions.ensure_chosen_action: ensure_chosen_action
+  - /adm_component/misc@step_definitions.populate_choice_info: populate_choice_info
+  # Use definitions in this file to override defaults defined above
+  - _self_
+
+attribute_definitions:
+  medical: ${adm.mu}
+  affiliation: ${adm.af}
+  merit: ${adm.mf}
+  search: ${adm.ss}
+  personal_safety: ${adm.ps}
+
+step_definitions:
+  predict_most_relevant:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+
+  regression_icl:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    attributes: ${adm.attribute_definitions}
+    prompt_template: ${ref:adm.prompt_template}
+
+  comparative_regression:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    prompt_template: ${ref:adm.prompt_template}
+    score_schema_template: ${adm.comparative_regression_choice_schema}
+
+instance:
+  _target_: align_system.algorithms.pipeline_adm.PipelineADM
+
+  steps:
+    # Reference the step instances we want to use in order
+    - ${ref:adm.step_definitions.format_choices}
+    - ${ref:adm.step_definitions.predict_most_relevant}
+    - ${ref:adm.step_definitions.regression_icl}
+    - ${ref:adm.step_definitions.comparative_regression}
+    - ${ref:adm.step_definitions.regression_rule_based_correction}
+    - ${ref:adm.step_definitions.scalar_alignment}
+    - ${ref:adm.step_definitions.justification_from_reasonings}
+    - ${ref:adm.step_definitions.ensure_chosen_action}
+    - ${ref:adm.step_definitions.populate_choice_info}

--- a/align_system/configs/adm_component/relevance/predict_most_relevant.yaml
+++ b/align_system/configs/adm_component/relevance/predict_most_relevant.yaml
@@ -1,0 +1,11 @@
+_target_: align_system.algorithms.relevance_adm_component.PredictMostRelevantADMComponent
+
+structured_inference_engine: ${ref:adm.structured_inference_engine}
+num_samples: 1
+attributes: ${ref:adm.attribute_definitions}
+system_prompt_template:
+  _target_: align_system.prompt_engineering.outlines_prompts.ProbeMostRelevantSystemPrompt
+prompt_template:
+  _target_: align_system.prompt_engineering.outlines_prompts.ProbeMostRelevantPrompt
+relevance_schema_template:
+  _target_: align_system.prompt_engineering.outlines_prompts.ProbeMostRelevantSchema

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_predict_most_relevant.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_predict_most_relevant.yaml
@@ -1,0 +1,17 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression_predict_most_relevant
+  - override /interface: ta3
+
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_fewshot_predict_most_relevant_test"
+  domain: "p2triage"
+  scenario_ids:
+  - June2025-AF-train
+  - June2025-MF-train
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true

--- a/align_system/prompt_engineering/outlines_prompts.py
+++ b/align_system/prompt_engineering/outlines_prompts.py
@@ -1354,3 +1354,80 @@ class ComparativeRegressionSchema():
         return comparative_regression_json_schema(
                 choices,
                 self.factor_lookup.get(attribute, self.default_factor))
+
+
+@outlines.prompt
+def probe_most_relevant_system_prompt(
+    kdmas
+):
+    """
+    You are a specialized algorithm tasked with assessing medical triage decisions \
+    in a military medical context.  Given a scenario and list of possible responses, \
+    your job is to assess which attribute is most relevant to the decision out of:
+
+    Attributes to consider are:
+    {% for kdma in kdmas %}
+    - {{ kdma.name }} : {{ kdma.description }}
+    {% endfor %}
+
+    Only provide the name of the most relevant attribute.
+    """
+
+
+class ProbeMostRelevantSystemPrompt():
+    def __init__(self):
+        self.environment = jinja2.Environment()
+
+    def __call__(self, target_attributes):
+        return probe_most_relevant_system_prompt(
+            target_attributes)
+
+
+@outlines.prompt
+def probe_most_relevant_prompt(situation, choices, kdmas):
+    """
+    Scenario:
+    {{ situation }}
+
+    Responses:
+    {% for choice, choice_dict in choices.items() %}
+    - {{ choice }}
+    {% endfor %}
+
+    Which of the following attributes is most relevant to the decision:
+    {% for kdma in kdmas %}
+    - {{ kdma.name }}
+    {% endfor %}
+    """
+
+
+class ProbeMostRelevantPrompt():
+    def __call__(self,
+                 scenario_description,
+                 choices,
+                 attributes):
+        return probe_most_relevant_prompt(
+            scenario_description,
+            {c: None for c in choices},
+            attributes)
+
+
+def probe_most_relevant_json_schema(target_attribute_names):
+    json_schema = {
+        "type": "object",
+        "properties": {
+            "most_relevant": {
+                "type": "string",
+                "enum": target_attribute_names
+            }
+        },
+        "required": ["most_relevant"],
+        "additionalProperties": False
+    }
+    return json.dumps(json_schema)
+
+
+class ProbeMostRelevantSchema():
+    def __call__(self, target_attribute_names):
+        return probe_most_relevant_json_schema(
+                target_attribute_names)


### PR DESCRIPTION
Adds a fewshot comp reg ADM with the added step of predicting most relevant attribute in multi-attribute targets. 
Example call to run: 
```
run_align_system +experiment=phase2_june_collab/pipeline_fewshot_comparative_regression_loo_predict_most_relevant +alignment_target=june2025/ADEPT-June2025-affiliation_merit-0.0_0.0.yaml
```