### PR TITLE
Adding fewshot comp reg and kaleido relevance mashup ADM

### DIFF
--- a/align_system/configs/adm/phase2_pipeline_fewshot_comparative_regression_kaleido_relevance.yaml
+++ b/align_system/configs/adm/phase2_pipeline_fewshot_comparative_regression_kaleido_relevance.yaml
@@ -1,0 +1,69 @@
+name: phase2_pipeline_zeroshot_comparative_regression_kaleido_relevance
+
+defaults:
+  # Import defaults into this namspace (adm) as @name, for further
+  # customization
+
+  # Shared variables / components
+  - /attribute@mu: medical_urgency
+  - /attribute@af: affiliation_focus
+  - /attribute@mf: merit_focus
+  - /attribute@ss: search_or_stay
+  - /attribute@ps: personal_safety
+  - /inference_engine@structured_inference_engine: outlines_structured_greedy
+  - /template/scenario_description@scenario_description_template: phase2
+  - /template/prompt@prompt_template: phase2_comparative_regression
+  - /template/output_schema@comparative_regression_choice_schema: phase2_comparative_regression_choice
+  # ADM components to be used in "steps"
+  - /adm_component/misc@step_definitions.format_choices: itm_format_choices
+  - /adm_component/regression@step_definitions.kaleido: phase2_kaleido
+  - /adm_component/misc@step_definitions.choice_relevance_to_probe_relevance: choice_relevance_to_probe_relevance
+  - /adm_component/misc@step_definitions.rename_kaleido_relevance_variables: rename_variables
+  - /adm_component/icl@step_definitions.regression_icl: phase2_comparative
+  - /adm_component/regression@step_definitions.comparative_regression: phase2_comparative_no_template
+  - /adm_component/misc@step_definitions.regression_rule_based_correction: phase2_regression_rule_based_correction
+  - /adm_component/alignment@step_definitions.scalar_alignment: medical_urgency_scalar
+  - /adm_component/misc@step_definitions.justification_from_reasonings: justification_from_reasonings
+  - /adm_component/misc@step_definitions.ensure_chosen_action: ensure_chosen_action
+  - /adm_component/misc@step_definitions.populate_choice_info: populate_choice_info
+  # Use definitions in this file to override defaults defined above
+  - _self_
+
+attribute_definitions:
+  medical: ${adm.mu}
+  affiliation: ${adm.af}
+  merit: ${adm.mf}
+  search: ${adm.ss}
+  personal_safety: ${adm.ps}
+
+step_definitions:
+  rename_kaleido_relevance_variables:
+    remapping:
+      relevance_prediction_scores: attribute_relevance_binary
+
+  regression_icl:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    attributes: ${adm.attribute_definitions}
+    prompt_template: ${ref:adm.prompt_template}
+
+  comparative_regression:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    prompt_template: ${ref:adm.prompt_template}
+    score_schema_template: ${adm.comparative_regression_choice_schema}
+
+instance:
+  _target_: align_system.algorithms.pipeline_adm.PipelineADM
+
+  steps:
+    # Reference the step instances we want to use in order
+    - ${ref:adm.step_definitions.format_choices}
+    - ${ref:adm.step_definitions.kaleido}
+    - ${ref:adm.step_definitions.choice_relevance_to_probe_relevance}
+    - ${ref:adm.step_definitions.rename_kaleido_relevance_variables}
+    - ${ref:adm.step_definitions.regression_icl}
+    - ${ref:adm.step_definitions.comparative_regression}
+    - ${ref:adm.step_definitions.regression_rule_based_correction}
+    - ${ref:adm.step_definitions.scalar_alignment}
+    - ${ref:adm.step_definitions.justification_from_reasonings}
+    - ${ref:adm.step_definitions.ensure_chosen_action}
+    - ${ref:adm.step_definitions.populate_choice_info}

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_kaleido_relevance.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_kaleido_relevance.yaml
@@ -1,0 +1,25 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression_kaleido_relevance
+  - override /interface: ta3
+    
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_fewshot_comp_reg_kaleido_relevance_test"
+  domain: "p2triage"
+  scenario_ids:
+  - June2025-AF-train
+  - June2025-MF-train
+
+# LOO - Remove for eval
+adm:
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          leave_one_out_strategy: 'scenario_description'
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true


### PR DESCRIPTION
Adds mashup ADM which uses Kaleido for relevance prediction and fewshot comp. reg. for score regression.

Example call to run:
```
run_align_system +experiment=phase2_june_collab/pipeline_fewshot_comparative_regression_loo_kaleido_relevance +alignment_target=june2025/ADEPT-June2025-affiliation_merit-0.0_0.0.yaml
```

In the future the speed could be improved by only regressing the attribute Kaleido predicted as relevant.