### PR TITLE
Bert similarity based relevance prediction

### DIFF
--- a/align_system/configs/adm/phase2_pipeline_fewshot_comparative_regression_bert_relevance.yaml
+++ b/align_system/configs/adm/phase2_pipeline_fewshot_comparative_regression_bert_relevance.yaml
@@ -1,0 +1,65 @@
+name: phase2_pipeline_fewshot_comparative_regression_bert_relevance
+
+defaults:
+  # Import defaults into this namspace (adm) as @name, for further
+  # customization
+
+  # Shared variables / components
+  - /attribute@mu: medical_urgency
+  - /attribute@af: affiliation_focus
+  - /attribute@mf: merit_focus
+  - /attribute@ss: search_or_stay
+  - /attribute@ps: personal_safety
+  - /inference_engine@structured_inference_engine: outlines_structured_greedy
+  - /template/scenario_description@scenario_description_template: phase2
+  - /template/prompt@prompt_template: phase2_comparative_regression
+  - /template/output_schema@comparative_regression_choice_schema: phase2_comparative_regression_choice
+  # ADM components to be used in "steps"
+  - /adm_component/misc@step_definitions.format_choices: itm_format_choices
+  - /adm_component/icl@step_definitions.regression_icl: phase2_comparative
+  - /adm_component/relevance@step_definitions.bert_relevance: bert_relevance
+  - /adm_component/regression@step_definitions.comparative_regression: phase2_comparative_no_template
+  - /adm_component/misc@step_definitions.regression_rule_based_correction: phase2_regression_rule_based_correction
+  - /adm_component/alignment@step_definitions.scalar_alignment: medical_urgency_scalar
+  - /adm_component/misc@step_definitions.justification_from_reasonings: justification_from_reasonings
+  - /adm_component/misc@step_definitions.ensure_chosen_action: ensure_chosen_action
+  - /adm_component/misc@step_definitions.populate_choice_info: populate_choice_info
+  # Use definitions in this file to override defaults defined above
+  - _self_
+
+attribute_definitions:
+  medical: ${adm.mu}
+  affiliation: ${adm.af}
+  merit: ${adm.mf}
+  search: ${adm.ss}
+  personal_safety: ${adm.ps}
+
+step_definitions:
+  regression_icl:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    attributes: ${adm.attribute_definitions}
+    prompt_template: ${ref:adm.prompt_template}
+
+  bert_relevance:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    prompt_template: ${ref:adm.prompt_template}
+
+  comparative_regression:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    prompt_template: ${ref:adm.prompt_template}
+    score_schema_template: ${adm.comparative_regression_choice_schema}
+
+instance:
+  _target_: align_system.algorithms.pipeline_adm.PipelineADM
+
+  steps:
+    # Reference the step instances we want to use in order
+    - ${ref:adm.step_definitions.format_choices}
+    - ${ref:adm.step_definitions.regression_icl}
+    - ${ref:adm.step_definitions.bert_relevance}
+    - ${ref:adm.step_definitions.comparative_regression}
+    - ${ref:adm.step_definitions.regression_rule_based_correction}
+    - ${ref:adm.step_definitions.scalar_alignment}
+    - ${ref:adm.step_definitions.justification_from_reasonings}
+    - ${ref:adm.step_definitions.ensure_chosen_action}
+    - ${ref:adm.step_definitions.populate_choice_info}

--- a/align_system/configs/adm_component/relevance/bert_relevance.yaml
+++ b/align_system/configs/adm_component/relevance/bert_relevance.yaml
@@ -1,0 +1,3 @@
+_target_: align_system.algorithms.relevance_adm_component.BertRelevanceADMComponent
+
+attributes: ${ref:adm.attribute_definitions}

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_bert_relevance.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_bert_relevance.yaml
@@ -1,0 +1,17 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression_bert_relevance
+  - override /interface: ta3
+
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_fewshot_bert_relevant_test"
+  domain: "p2triage"
+  scenario_ids:
+  - June2025-AF-train
+  - June2025-MF-train
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_bert_relevance.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_bert_relevance.yaml
@@ -12,6 +12,14 @@ interface:
   - June2025-AF-train
   - June2025-MF-train
 
+# LOO - Remove for eval
+adm:
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          leave_one_out_strategy: 'scenario_description'
+
 apply_action_filtering: false
 force_determinism: true
 align_to_target: true

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_predict_most_relevant.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_predict_most_relevant.yaml
@@ -12,6 +12,14 @@ interface:
   - June2025-AF-train
   - June2025-MF-train
 
+# LOO - Remove for eval
+adm:
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          leave_one_out_strategy: 'scenario_description'
+
 apply_action_filtering: false
 force_determinism: true
 align_to_target: true


### PR DESCRIPTION
Adds an ADM that uses the BERT similairty between the current probe and ICL examples to determine which attribute is most relevant. 
Example call to run:
```
run_align_system +experiment=phase2_june_collab/pipeline_fewshot_comparative_regression_loo_bert_relevance +alignment_target=june2025/ADEPT-June2025-affiliation_merit-0.0_0.0.yaml
```