### PR TITLE
Prepend the scenario unstructured to the scene/probe unstructured

### DIFF
--- a/align_system/interfaces/ta3_caci_action_based_service.py
+++ b/align_system/interfaces/ta3_caci_action_based_service.py
@@ -163,6 +163,10 @@ class TA3CACIActionBasedScenario(ActionBasedScenarioInterface):
             updated_state = take_or_intend(
                 session_id=self.session_id,
                 action=action)
+
+            updated_state.unstructured = "{}\n{}".format(
+                updated_state.threat_state.unstructured,
+                updated_state.unstructured)
         else:
             updated_state = take_or_intend(
                 session_id=self.session_id,
@@ -181,5 +185,12 @@ class TA3CACIActionBasedScenario(ActionBasedScenarioInterface):
         )
 
     def get_state(self):
-        return self.connection.get_scenario_state(
+        state = self.connection.get_scenario_state(
             session_id=self.session_id, scenario_id=self.scenario.id)
+
+        if self.domain == "p2triage":
+            state.unstructured = "{}\n{}".format(
+                state.threat_state.unstructured,
+                state.unstructured)
+
+        return state


### PR DESCRIPTION
Phase2 data has been updated to move the scenario description out from the `state.unstructured` field into the unstructured field for the scenario (and it's been put into the `threat_state.unstructured` as a convenience for us).  This PR "hacks" the unstructured state text coming back from the server to put that scenario text in front again (so the Phase2 ADMs don't need to change anything).