### PR TITLE
Reduce code duplication between medical urgency alignment functions

### DIFF
--- a/align_system/algorithms/alignment_adm_component.py
+++ b/align_system/algorithms/alignment_adm_component.py
@@ -126,180 +126,9 @@ class MedicalUrgencyAlignmentADMComponent(ADMComponent):
     def run_returns(self):
         return ('chosen_choice', 'best_sample_idx')
 
-    def _midpoint_eqn(self, medical_delta, attribute_delta, total_weight=2):
-        # Midpoint equation from ADEPT
-        return 0.5 + (medical_delta - attribute_delta)/total_weight
-
-    def run(
-        self,
-        attribute_prediction_scores,
-        alignment_target,
-        attribute_relevance=None,
-    ):
-        """
-        Align based on medical urgency/KDMA tradeoff
-
-        attribute_prediction_scores: dict[str, dict[str, float | list[float]]]
-            Dictionary of choices mapped to KMDA value predictions, including medical
-            urgency prediction
-        alignment_target: alignment target info
-        attribute_relevance: dict[str, float | list[float]]
-            Dictionary of probe level KDMA relevance predictions
-        """
-        med_urg_str = "medical"
-
-        if alignment_target is None:
-            raise RuntimeError(
-                "Assumption violated: `alignment_target` was None"
-            )
-
-        target_kdmas = alignment_target_to_attribute_targets(
-            alignment_target,
-            self.attributes)
-        target_kdmas = [dict(t) for t in target_kdmas]
-
-        def _handle_single_value(predictions):
-            if not isinstance(predictions, list):
-                return [predictions]
-            return predictions
-
-        # Take a dictionary of predictions (with KDMAs as key) and return average values per KDMA
-        def _get_avg_pred(all_predictions):
-            pred_dict_out = {}
-            for target_kdma in target_kdmas:
-                kdma = target_kdma["kdma"]
-                if kdma not in all_predictions:
-                    continue
-                preds = _handle_single_value(all_predictions[kdma])
-                pred_dict_out[kdma] = sum(preds) / len(preds)
-
-            if med_urg_str in all_predictions:
-                preds = _handle_single_value(all_predictions[med_urg_str])
-                pred_dict_out[med_urg_str] = sum(preds) / len(preds)
-
-            return pred_dict_out
-
-        choices = list(attribute_prediction_scores.keys())
-        if len(choices) != 2:
-            raise NotImplementedError("This alignment function has not yet been implemented for !=2 choices")
-
-        # Compute averages of predicted values
-        predictions = []
-        for choice, all_kdma_predictions in attribute_prediction_scores.items():
-            pred_dict = {"choice": choice}
-
-            # Get medical urgency
-            if med_urg_str not in all_kdma_predictions:
-                raise RuntimeError("Medical Urgency predictions required for this alignment function")
-            medical_urgency_preds = _handle_single_value(all_kdma_predictions[med_urg_str])
-            pred_dict[med_urg_str] = sum(medical_urgency_preds) / len(medical_urgency_preds)
-
-            # Get KDMA predictions relevant to target
-            pred_dict["kdmas"] = _get_avg_pred(all_kdma_predictions)
-
-            predictions.append(pred_dict)
-
-        # Get relevance predictions relevant to target
-        probe_relevance = {}
-        if attribute_relevance is not None:
-            probe_relevance = _get_avg_pred(attribute_relevance)
-
-        # Sort by medical urgency (descending)
-        predictions.sort(key=lambda pred: pred[med_urg_str], reverse=True)
-
-        # Guaranteed to only have 2 choices at this point due to earlier checks
-        opt_a, opt_b = predictions
-        medical_weight = probe_relevance[med_urg_str] if med_urg_str in probe_relevance else 1.0
-        medical_delta = medical_weight * (opt_a[med_urg_str] - opt_b[med_urg_str])
-
-        # TODO: Figure out what it means to be the best prediction for this alignment function
-        best_sample_idx = 0
-
-        # Compute midpoint per attribute
-        attribute_weights = {}
-        attribute_deltas = {}
-        attribute_midpoints = {}
-        for target_kdma in target_kdmas:
-            kdma = target_kdma["kdma"]
-            attribute_weights[kdma] = probe_relevance[kdma] if kdma in probe_relevance else 1.0
-            # May not have predictions for this KDMA if it had 0 relevance
-            if math.isclose(attribute_weights[kdma], 0.):
-                continue
-            attribute_deltas[kdma] = attribute_weights[kdma] * (opt_b["kdmas"][kdma] - opt_a["kdmas"][kdma])
-            attribute_midpoints[kdma] = self._midpoint_eqn(
-                medical_delta, attribute_deltas[kdma], total_weight=(medical_weight + attribute_weights[kdma])
-            )
-            log.info(f"{kdma} midpoint: {attribute_midpoints[kdma]}")
-
-        votes = {idx: 0 for idx in range(2)}
-        for target_kdma in target_kdmas:
-            kdma = target_kdma["kdma"]
-            if math.isclose(attribute_weights[kdma], 0.):  # don't consider attributes with 0 weight
-                log.info(f"{kdma}: Removing from consideration, 0 weight")
-                continue
-
-            attr_delta = attribute_deltas[kdma]
-            if math.isclose(medical_delta, 0.):
-                if math.isclose(attr_delta, 0.):  # patient is same medically and attribute-wise, don't vote
-                    log.info(f"{kdma}: Patients are tied both medically and attribute-wise, not voting")
-                    continue
-                elif attr_delta > 0:
-                    votes[1] += 1
-                else:
-                    votes[0] += 1
-                log.info(f"{kdma}: Patients are tied medically, voting for attribute-worthy")
-            elif attr_delta < 0 or math.isclose(attr_delta, 0.):  # same patient is medically and attribute worthy
-                log.info(f"{kdma}: Voting for patient that is both medically and attribute-worthy")
-                votes[0] += 1
-            else:
-                attr_target = target_kdma["value"]
-                attr_midpoint = attribute_midpoints[kdma]
-                if math.isclose(attr_target, attr_midpoint):  # Midpoint == target, tie
-                    log.info(f"{kdma}: Target is exactly midpoint, not voting")
-                    continue
-                elif attr_target < attr_midpoint:
-                    log.info(f"{kdma}: Target is less than midpoint, voting for medically-worthy.")
-                    votes[0] += 1
-                else:  # attr_target > attr_midpoint
-                    log.info(f"{kdma}: Target is greater than midpoint, voting for attribute-worthy")
-                    votes[1] += 1
-
-        log.explain(votes)
-
-        max_votes = max(votes.values())
-        max_keys = [key for key, value in votes.items() if math.isclose(value, max_votes)]
-        log.info(f"Max vote keys: {max_keys}")
-
-        if len(max_keys) > 1:  # tie, choose randomly
-            log.explain("Patients predicted to have same attribute worthiness, randomly choosing")
-            return (random.choice([predictions[key]["choice"] for key in max_keys]), best_sample_idx)
-        else:
-            return (predictions[max_keys[0]]["choice"], best_sample_idx)
-
-
-class MedicalUrgencyAlignmentWeightedADMComponent(ADMComponent):
-    def __init__(
-        self,
-        attributes=None
-    ):
-        if attributes is None:
-            attributes = {}
-        self.attributes = attributes
-
-    def run_returns(self):
-        return ('chosen_choice', 'best_sample_idx')
-
     def _midpoint_eqn(self, kdma, opt_a_value, medical_delta, attr_delta):
-        medical_weights = {"affiliation": 2, "merit": 4}
-        medical_weight = medical_weights.get(kdma, 1.0)
-
         # Midpoint equation from ADEPT
-        if kdma == "affiliation":
-            return (opt_a_value + medical_weight*medical_delta - opt_a_value*medical_delta)/2
-        elif kdma == "merit":
-            return (opt_a_value + medical_weight*medical_delta)/4
-        else:
-            return 0.5 + (medical_weight*medical_delta - attr_delta)/2
+        return 0.5 + (medical_delta - attr_delta)/2
 
     def run(
         self,
@@ -448,3 +277,17 @@ class MedicalUrgencyAlignmentWeightedADMComponent(ADMComponent):
             return (random.choice([predictions[key]["choice"] for key in max_keys]), best_sample_idx)
         else:
             return (predictions[max_keys[0]]["choice"], best_sample_idx)
+
+
+class MedicalUrgencyAlignmentWeightedADMComponent(MedicalUrgencyAlignmentADMComponent):
+    def _midpoint_eqn(self, kdma, opt_a_value, medical_delta, attr_delta):
+        medical_weights = {"affiliation": 2, "merit": 4}
+        medical_weight = medical_weights.get(kdma, 1.0)
+
+        # Midpoint equation from ADEPT
+        if kdma == "affiliation":
+            return (opt_a_value + medical_weight*medical_delta - opt_a_value*medical_delta)/2
+        elif kdma == "merit":
+            return (opt_a_value + medical_weight*medical_delta)/4
+        else:
+            return 0.5 + (medical_weight*medical_delta - attr_delta)/2

--- a/align_system/tests/test_alignment_adm_component.py
+++ b/align_system/tests/test_alignment_adm_component.py
@@ -5,7 +5,13 @@ from align_system.algorithms.alignment_adm_component import (
     MedicalUrgencyAlignmentADMComponent,
     MedicalUrgencyAlignmentWeightedADMComponent)
 
-
+@pytest.mark.parametrize(
+    ("alignment_fn_class"),
+    [
+        MedicalUrgencyAlignmentADMComponent,
+        MedicalUrgencyAlignmentWeightedADMComponent,
+    ]
+ )
 class TestMedicalUrgencyAlignmentADMComponent:
     attribute_definitions = {
         "KDMA_A": {
@@ -205,9 +211,9 @@ class TestMedicalUrgencyAlignmentADMComponent:
             "multiple predictions, target below midpoint (0.625)"
         ],
     )
-    def test_run(self, attribute_prediction_scores, alignment_target, exp_choice, exp_raises):
+    def test_run(self, alignment_fn_class, attribute_prediction_scores, alignment_target, exp_choice, exp_raises):
         """ Test expected outcomes """
-        alignment_fn = MedicalUrgencyAlignmentADMComponent(
+        alignment_fn = alignment_fn_class(
             TestMedicalUrgencyAlignmentADMComponent.attribute_definitions
         )
 
@@ -468,673 +474,11 @@ class TestMedicalUrgencyAlignmentADMComponent:
         ],
     )
     def test_run_with_multi_kdma(
-        self, attribute_prediction_scores, alignment_target, exp_choice
+        self, alignment_fn_class, attribute_prediction_scores, alignment_target, exp_choice
     ):
         """ Test expected outcomes """
-        alignment_fn = MedicalUrgencyAlignmentADMComponent(
+        alignment_fn = alignment_fn_class(
             TestMedicalUrgencyAlignmentADMComponent.attribute_definitions
-        )
-
-        # Only checking selected choice as best sample index not yet implemented
-        assert alignment_fn.run(attribute_prediction_scores, alignment_target)[0] == exp_choice
-
-    @pytest.mark.parametrize(
-        ("attribute_prediction_scores", "alignment_target", "attribute_relevance", "exp_choice"),
-        [
-            # Binary relevance. KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.2},
-                        {"kdma": "KDMA_B", "value": 0.6},
-                    ],
-                },
-                {"KDMA_A": 1.0, "KDMA_B": 0.0},
-                "Choice 1",  # Target below midpoint
-            ),
-            # Same as previous, change KDMA B target (shouldn't matter)
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.2},
-                        {"kdma": "KDMA_B", "value": 0.2},
-                    ],
-                },
-                {"KDMA_A": 1.0, "KDMA_B": 0.0},
-                "Choice 1",  # Target below midpoint
-            ),
-            # Binary relevance. KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.9},
-                        {"kdma": "KDMA_B", "value": 0.6},
-                    ],
-                },
-                {"KDMA_A": 1.0, "KDMA_B": 0.0},
-                "Choice 0",  # Target above midpoint
-            ),
-            # Binary relevance. KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.9},
-                        {"kdma": "KDMA_B", "value": 0.6},
-                    ],
-                },
-                {"KDMA_A": 0.0, "KDMA_B": 1.0},
-                "Choice 0",  # Target above midpoint
-            ),
-            # Medical relevance. KDMA_A midpoint is ~0.788
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.8},
-                    ],
-                },
-                {"medical": 1.25, "KDMA_A": 1.0},
-                "Choice 0",  # Target above midpoint
-            ),
-            # Medical relevance. KDMA_A midpoint is ~0.788
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.75},
-                    ],
-                },
-                {"medical": 1.25, "KDMA_A": 1.0},
-                "Choice 1",  # Target below midpoint
-            ),
-            # Medical relevance. KDMA_A midpoint is ~0.788, KDMA_B midpoint is ~0.611
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.8},
-                        {"kdma": "KDMA_B", "value": 0.65},
-                    ],
-                },
-                {"medical": 1.25, "KDMA_A": 1.0, "KDMA_B": 1.0},
-                "Choice 0",  # Both above midpoint
-            ),
-            # Medical relevance. KDMA_A midpoint is ~0.788, KDMA_B midpoint is ~0.611
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.75},
-                        {"kdma": "KDMA_B", "value": 0.60},
-                    ],
-                },
-                {"medical": 1.25, "KDMA_A": 1.0, "KDMA_B": 1.0},
-                "Choice 1",  # Both below midpoint
-            ),
-            # KDMA_A midpoint is 0.96, KDMA_B midpoint is ~0.733
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 1.0},
-                        {"kdma": "KDMA_B", "value": 0.75},
-                    ],
-                },
-                {"KDMA_A": 0.25, "KDMA_B": 0.5},
-                "Choice 0",  # Both above midpoint
-            ),
-            # KDMA_A midpoint is 0.96, KDMA_B midpoint is ~0.733
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.95},
-                        {"kdma": "KDMA_B", "value": 0.70},
-                    ],
-                },
-                {"KDMA_A": 0.25, "KDMA_B": 0.5},
-                "Choice 1",  # Both below midpoint
-            ),
-        ],
-    )
-    def test_run_with_explicit_relevance(
-        self, attribute_prediction_scores, alignment_target, attribute_relevance, exp_choice
-    ):
-        """ Test expected outcomes """
-        alignment_fn = MedicalUrgencyAlignmentADMComponent(
-            TestMedicalUrgencyAlignmentADMComponent.attribute_definitions
-        )
-
-        # Only checking selected choice as best sample index not yet implemented
-        assert alignment_fn.run(attribute_prediction_scores, alignment_target, attribute_relevance)[0] == exp_choice
-
-    @pytest.mark.parametrize(
-        ("medical_delta", "attribute_delta", "total_weight", "exp_value"),
-        [
-            (0.7, 0.1, None, 0.8),
-            (0.3, 0.2, None, 0.55),
-            (0.9, 0.4, None, 0.75),
-            (0.1, 0.8, None, 0.15),
-            (0.7, 0.1, 2, 0.8),  # Should be the exact same as the equivalent 'None' total_weight case
-            (0.3, 0.2, 4, 0.525),
-            (0.1, 0.8, 1.75, 0.1),
-        ],
-    )
-    def test_midpoint_eqn(self, medical_delta, attribute_delta, total_weight, exp_value):
-        """ Regression test to ensure equation doesn't get inadvertently modified """
-        alignment_fn = MedicalUrgencyAlignmentADMComponent(
-            TestMedicalUrgencyAlignmentADMComponent.attribute_definitions
-        )
-
-        if total_weight is None:
-            result = alignment_fn._midpoint_eqn(medical_delta, attribute_delta)
-        else:
-            result = alignment_fn._midpoint_eqn(medical_delta, attribute_delta, total_weight)
-
-        assert result == pytest.approx(exp_value)
-
-
-class TestMedicalUrgencyAlignmentWeightedADMComponent:
-    attribute_definitions = {
-        "KDMA_A": {
-            "name": "KDMA A",
-            "kdma": "KDMA_A",
-            "description": "Test KDMA A",
-        },
-        "KDMA_B": {
-            "name": "KDMA B",
-            "kdma": "KDMA_B",
-            "description": "Test KDMA B",
-        },
-        "KDMA_C": {
-            "name": "KDMA C",
-            "kdma": "KDMA_C",
-            "description": "Test KDMA C",
-        },
-    }
-
-    @pytest.mark.parametrize(
-        ("attribute_prediction_scores", "alignment_target", "exp_choice", "exp_raises"),
-        [
-            # No alignment target
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.1, "KDMA_B": 0.8},
-                    "Choice 1": {"medical": 0.6, "KDMA_A": 0.3, "KDMA_B": 0.5},
-                },
-                None,
-                None,  # Raise expected so doesn't matter
-                pytest.raises(RuntimeError, match=r"Assumption violated: `alignment_target` was None"),
-            ),
-            # No medical predictions
-            (
-                {
-                    "Choice 0": {"KDMA_A": 0.1, "KDMA_B": 0.8},
-                    "Choice 1": {"KDMA_A": 0.3, "KDMA_B": 0.5},
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_A", "value": 0.3}],
-                },
-                None,  # Raise expected so doesn't matter
-                pytest.raises(RuntimeError, match=r"Medical Urgency predictions required"),
-            ),
-            # >2 choices
-            (
-                {
-                    "Choice 0": {"medical": 0.9, "KDMA_A": 0.1},
-                    "Choice 1": {"medical": 0.2, "KDMA_A": 0.3},
-                    "Choice 2": {"medical": 0.6, "KDMA_A": 0.4},
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_A", "value": 0.3}],
-                },
-                None,  # Raise expected so doesn't matter
-                pytest.raises(NotImplementedError, match=r"This alignment function has not yet been"),
-            ),
-            # <2 choices
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_B": 0.8},
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_B", "value": 0.7}],
-                },
-                None,  # Raise expected so doesn't matter
-                pytest.raises(NotImplementedError, match=r"This alignment function has not yet been"),
-            ),
-            # Same medical
-            (
-                {
-                    "Choice 0": {"medical": 0.5, "KDMA_A": 0.1},
-                    "Choice 1": {"medical": 0.5, "KDMA_A": 0.9},
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_A", "value": 0.3}],
-                },
-                "Choice 1",  # Attribute worthy patient
-                does_not_raise(),
-            ),
-            # Same patient is medically AND attribute worthy
-            (
-                {
-                    "Choice 0": {"medical": 0.5, "KDMA_A": 0.1},
-                    "Choice 1": {"medical": 0.9, "KDMA_A": 0.9},
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_A", "value": 0.3}],
-                },
-                "Choice 1",
-                does_not_raise(),
-            ),
-            # Target above midpoint (0.35)
-            (
-                {
-                    "Choice 0": {"medical": 0.9, "KDMA_A": 0.1},
-                    "Choice 1": {"medical": 0.4, "KDMA_A": 0.9},
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_A", "value": 0.7}],
-                },
-                "Choice 1",  # Choose attribute-worthy patient
-                does_not_raise(),
-            ),
-            # Target below midpoint (0.35)
-            (
-                {
-                    "Choice 0": {"medical": 0.9, "KDMA_A": 0.1},
-                    "Choice 1": {"medical": 0.4, "KDMA_A": 0.9},
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_A", "value": 0.1}],
-                },
-                "Choice 0",  # Chose medically-worthy patient
-                does_not_raise(),
-            ),
-            # Target above midpoint (0.55)
-            (
-                {
-                    "Choice 0": {"medical": 0.3, "KDMA_B": 0.8},
-                    "Choice 1": {"medical": 0.7, "KDMA_B": 0.5},
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_B", "value": 0.65}],
-                },
-                "Choice 0",  # Choose attribute-worthy patient
-                does_not_raise(),
-            ),
-            # Target below midpoint (0.55)
-            # Extra KDMAs should be ignored
-            (
-                {
-                    "Choice 0": {"medical": 0.3, "KDMA_A": 0.1, "KDMA_B": 0.8},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.9, "KDMA_B": 0.5},
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_B", "value": 0.25}],
-                },
-                "Choice 1",  # Choose medically-worthy patient
-                does_not_raise(),
-            ),
-            # Target above midpoint (0.8)
-            (
-                {
-                    "Choice 0": {"medical": 0.2, "KDMA_A": 0.6},
-                    "Choice 1": {"medical": 0.9, "KDMA_A": 0.5},
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_A", "value": 0.9}],
-                },
-                "Choice 0",  # Choose attribute-worthy patient
-                does_not_raise(),
-            ),
-            # Target below midpoint (0.8)
-            (
-                {
-                    "Choice 0": {"medical": 0.2, "KDMA_A": 0.6},
-                    "Choice 1": {"medical": 0.9, "KDMA_A": 0.5},
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_A", "value": 0.3}],
-                },
-                "Choice 1",  # Chose medically-worthy patient
-                does_not_raise(),
-            ),
-            # Multiple predictions, predictions of different lengths, target above midpoint (0.625)
-            (
-                {
-                    "Choice 0": {"medical": [0.2, 0.3, 0.3, 0.2], "KDMA_A": [0.6, 0.8]},  # medical: 0.25, KDMA_A: 0.7
-                    "Choice 1": {"medical": [0.9, 0.5, 0.9, 0.5], "KDMA_A": [0.5]},  # medical: 0.7, KDMA_A: 0.5
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_A", "value": 0.7}],
-                },
-                "Choice 0",  # Chose attribute-worthy patient
-                does_not_raise(),
-            ),
-            # Multiple predictions, predictions of different lengths, target below midpoint (0.625)
-            (
-                {
-                    "Choice 0": {"medical": [0.2, 0.3, 0.3, 0.2], "KDMA_A": [0.6, 0.8]},  # medical: 0.25, KDMA_A: 0.7
-                    "Choice 1": {"medical": [0.9, 0.5, 0.9, 0.5], "KDMA_A": [0.5]},  # medical: 0.7, KDMA_A: 0.5
-                },
-                {
-                    "kdma_values": [{"kdma": "KDMA_A", "value": 0.6}],
-                },
-                "Choice 1",  # Chose medically-worthy patient
-                does_not_raise(),
-            ),
-            # We choose randomly for target == midpoint, so no guarantees there
-        ],
-        ids=[
-            "no target", "no medical preds", ">2 choices", "<2 choices", "same medical",
-            "same medical and attribute patient", "target above midpoint (0.35)", "target below midpoint (0.35)",
-            "target above midpoint (0.55)", "target below midpoint (0.55), extraneous KDMAs",
-            "target above midpoint (0.8)", "target below midpoint (0.8)", "multiple predictions, target above midpoint (0.625)",
-            "multiple predictions, target below midpoint (0.625)"
-        ],
-    )
-    def test_run(self, attribute_prediction_scores, alignment_target, exp_choice, exp_raises):
-        """ Test expected outcomes """
-        alignment_fn = MedicalUrgencyAlignmentWeightedADMComponent(
-            TestMedicalUrgencyAlignmentWeightedADMComponent.attribute_definitions
-        )
-
-        with exp_raises:
-            # Only checking selected choice as best sample index not yet implemented
-            assert alignment_fn.run(attribute_prediction_scores, alignment_target)[0] == exp_choice
-
-    @pytest.mark.parametrize(
-        ("attribute_prediction_scores", "alignment_target", "exp_choice"),
-        [
-            # Same medical, one patient favored by all attributes
-            (
-                {
-                    "Choice 0": {"medical": 0.5, "KDMA_A": 0.1, "KDMA_B": 0.2},
-                    "Choice 1": {"medical": 0.5, "KDMA_A": 0.9, "KDMA_B": 0.7},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.3},
-                        {"kdma": "KDMA_B", "value": 0.7},
-                    ],
-                },
-                "Choice 1",  # Attribute worthy patient
-            ),
-            # Same medical, one attribute tied
-            (
-                {
-                    "Choice 0": {"medical": 0.5, "KDMA_A": 0.9, "KDMA_B": 0.4},
-                    "Choice 1": {"medical": 0.5, "KDMA_A": 0.9, "KDMA_B": 0.1},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.9},
-                        {"kdma": "KDMA_B", "value": 0.1},
-                    ],
-                },
-                "Choice 0",  # Attribute worthy patient
-            ),
-            # Fully tied patients would be random choice,
-            # Same patient is medically and attribute favored
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.1, "KDMA_B": 0.2},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.9, "KDMA_B": 0.7},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.6},
-                        {"kdma": "KDMA_B", "value": 0.1},
-                    ],
-                },
-                "Choice 1",  # Medically and attribute worthy patient
-            ),
-            # Same medical/attr favored patient for KDMA_A, KDMA_B midpoint is 0.55
-            # Targets above 0.55 for KDMA_B would be tie vote
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.1, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.9, "KDMA_B": 0.2}, # KDMA_A, KDMA_B if target below 0.55
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.1},
-                        {"kdma": "KDMA_B", "value": 0.3},
-                    ],
-                },
-                "Choice 1",
-            ),
-            # Same as previous but new target for KDMA_A (shouldn't matter)
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.1, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.9, "KDMA_B": 0.2}, # KDMA_A, KDMA_B if target below 0.55
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.9},
-                        {"kdma": "KDMA_B", "value": 0.3},
-                    ],
-                },
-                "Choice 1",
-            ),
-            # KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.1},
-                        {"kdma": "KDMA_B", "value": 0.3},
-                    ],
-                },
-                "Choice 1",  # Both targets below midpoint
-            ),
-            # KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.9},
-                        {"kdma": "KDMA_B", "value": 0.6},
-                    ],
-                },
-                "Choice 0",  # Both targets above midpoint
-            ),
-            # KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.75},
-                        {"kdma": "KDMA_B", "value": 0.6},
-                    ],
-                },
-                "Choice 0",  # KDMA_A target is exactly midpoint so its votes don't count
-            ),
-            # KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55. KDMA_C isn't in target so it should be ignored
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7, "KDMA_C": 0.9},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2, "KDMA_C": 0.1},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.75},
-                        {"kdma": "KDMA_B", "value": 0.2},
-                    ],
-                },
-                "Choice 1",  # KDMA_A target is exactly midpoint so its votes don't count
-            ),
-            # More than 2 targets. KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55, KDMA_C midpoint is 0.4
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7, "KDMA_C": 0.9},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2, "KDMA_C": 0.1},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.9},
-                        {"kdma": "KDMA_B", "value": 0.6},
-                        {"kdma": "KDMA_C", "value": 0.8},
-                    ],
-                },
-                "Choice 0",  # All targets above midpoint
-            ),
-            # More than 2 targets. KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55, KDMA_C midpoint is 0.4
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7, "KDMA_C": 0.9},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2, "KDMA_C": 0.1},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.9},
-                        {"kdma": "KDMA_B", "value": 0.6},
-                        {"kdma": "KDMA_C", "value": 0.2},
-                    ],
-                },
-                "Choice 0",  # 2/3 above midpoint
-            ),
-            # More than 2 targets. KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55, KDMA_C midpoint is 0.4
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7, "KDMA_C": 0.9},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2, "KDMA_C": 0.1},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.9},
-                        {"kdma": "KDMA_B", "value": 0.1},
-                        {"kdma": "KDMA_C", "value": 0.8},
-                    ],
-                },
-                "Choice 0",  # 2/3 above midpoint
-            ),
-            # More than 2 targets. KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55, KDMA_C midpoint is 0.4
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7, "KDMA_C": 0.9},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2, "KDMA_C": 0.1},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.5},
-                        {"kdma": "KDMA_B", "value": 0.6},
-                        {"kdma": "KDMA_C", "value": 0.8},
-                    ],
-                },
-                "Choice 0",  # 2/3 above midpoint
-            ),
-            # More than 2 targets. KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55, KDMA_C midpoint is 0.4
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7, "KDMA_C": 0.9},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2, "KDMA_C": 0.1},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.5},
-                        {"kdma": "KDMA_B", "value": 0.2},
-                        {"kdma": "KDMA_C", "value": 0.8},
-                    ],
-                },
-                "Choice 1",  # 2/3 below midpoint
-            ),
-            # More than 2 targets. KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55, KDMA_C midpoint is 0.4
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7, "KDMA_C": 0.9},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2, "KDMA_C": 0.1},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.5},
-                        {"kdma": "KDMA_B", "value": 0.2},
-                        {"kdma": "KDMA_C", "value": 0.4},
-                    ],
-                },
-                "Choice 1",  # 2/3 below midpoint, other exactly midpoint
-            ),
-            # More than 2 targets. KDMA_A midpoint is 0.75, KDMA_B midpoint is 0.55, KDMA_C midpoint is 0.4
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.6, "KDMA_B": 0.7, "KDMA_C": 0.9},
-                    "Choice 1": {"medical": 0.7, "KDMA_A": 0.5, "KDMA_B": 0.2, "KDMA_C": 0.1},
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.75},
-                        {"kdma": "KDMA_B", "value": 0.2},
-                        {"kdma": "KDMA_C", "value": 0.4},
-                    ],
-                },
-                "Choice 1",  # 1 below midpoint, other 2 exactly midpoint
-            ),
-            # Multiple predictions. KDMA_A midpoint is 0.5, KDMA_B midpoint is 0.325
-            (
-                {
-                    "Choice 0": {"medical": 0.1, "KDMA_A": [0.6, 0.5, 0.4], "KDMA_B": [0.7, 0.6]},  # KDMA_A: 0.5, KDMA_B: 0.65
-                    "Choice 1": {"medical": [0.7, 0.6], "KDMA_A": [0.5, 0.3], "KDMA_B": 0.2},  # medical: 0.6, KDMA_A: 0.4
-                },
-                {
-                    "kdma_values": [
-                        {"kdma": "KDMA_A", "value": 0.75},
-                        {"kdma": "KDMA_B", "value": 0.6},
-                    ],
-                },
-                "Choice 0",  # Both targets above midpoint
-            ),
-        ],
-    )
-    def test_run_with_multi_kdma(
-        self, attribute_prediction_scores, alignment_target, exp_choice
-    ):
-        """ Test expected outcomes """
-        alignment_fn = MedicalUrgencyAlignmentWeightedADMComponent(
-            TestMedicalUrgencyAlignmentWeightedADMComponent.attribute_definitions
         )
 
         # Only checking selected choice as best sample index not yet implemented
@@ -1236,11 +580,11 @@ class TestMedicalUrgencyAlignmentWeightedADMComponent:
         ],
     )
     def test_run_with_explicit_relevance(
-        self, attribute_prediction_scores, alignment_target, attribute_relevance, exp_choice
+        self, alignment_fn_class, attribute_prediction_scores, alignment_target, attribute_relevance, exp_choice
     ):
         """ Test expected outcomes """
-        alignment_fn = MedicalUrgencyAlignmentWeightedADMComponent(
-            TestMedicalUrgencyAlignmentWeightedADMComponent.attribute_definitions
+        alignment_fn = alignment_fn_class(
+            TestMedicalUrgencyAlignmentADMComponent.attribute_definitions
         )
 
         # Only checking selected choice as best sample index not yet implemented
@@ -1254,13 +598,44 @@ class TestMedicalUrgencyAlignmentWeightedADMComponent:
             ("KDMA_A", 0.6, 0.9, 0.4, 0.75),
             ("KDMA_A", 0.0, 0.1, 0.8, 0.15),
             ("KDMA_A", 0.7, 0.7, 0.1, 0.8),  # Should be the exact same as the otherwise equivalent opt_a case
+            ("KDMA_A", 1.0, 0.3, 0.2, 0.55),
+            ("KDMA_A", 0.65, 0.1, 0.8, 0.15),
+        ],
+    )
+    def test_midpoint_eqn(self, alignment_fn_class, kdma, opt_a_value, medical_delta, attribute_delta, exp_value):
+        """ Regression test to ensure equation doesn't get inadvertently modified """
+        alignment_fn = alignment_fn_class(
+            TestMedicalUrgencyAlignmentADMComponent.attribute_definitions
+        )
+
+        assert (
+            alignment_fn._midpoint_eqn(kdma, opt_a_value, medical_delta, attribute_delta) == pytest.approx(exp_value)
+        )
+
+class TestMedicalUrgencyAlignmentWeightedADMComponent:
+    attribute_definitions = {
+        "KDMA_A": {
+            "name": "Merit Focus",
+            "kdma": "merit",
+            "description": "Test merit focus KDMA",
+        },
+        "KDMA_B": {
+            "name": "Affiliation Focus",
+            "kdma": "affiliation",
+            "description": "Test affiliation focus KDMA",
+        }
+    }
+
+    @pytest.mark.parametrize(
+        ("kdma", "opt_a_value", "medical_delta", "attribute_delta", "exp_value"),
+        [
             ("affiliation", 0.3, 0.7, 0.1, 0.745),
             ("merit", 0.5, 0.3, 0.2, 0.425),
             ("affiliation", 0.3, 0.7, 0.8, 0.745),  # Attribute delta shouldn't change result for affiliation/merit
             ("merit", 0.5, 0.3, 0.8, 0.425),
         ],
     )
-    def test_midpoint_eqn(self, kdma, opt_a_value, medical_delta, attribute_delta, exp_value):
+    def test_weighted_midpoint_eqn(self, kdma, opt_a_value, medical_delta, attribute_delta, exp_value):
         """ Regression test to ensure equation doesn't get inadvertently modified """
         alignment_fn = MedicalUrgencyAlignmentWeightedADMComponent(
             TestMedicalUrgencyAlignmentWeightedADMComponent.attribute_definitions


### PR DESCRIPTION
Potential refactor for the medical urgency alignment functions. Not 100% consistent with previous behavior but the pieces that changed were unused. Those pieces are:

1. Relevance now affects voting weight instead of affecting the midpoint directly (I think this is what @dmjoy  might have been arguing for when the initial alignment function was merged). Regardless, we've only used binary relevance so far, so we weren't really hitting this functionality. [unit tests still pass, with the exception of the 2 non-binary relevance tests which are now updated for this new behavior]
2. Removal of on-the-fly medical urgency relevance prediction (`medical_weight`). The previous function now just uses a value of 1.0, the weighted class uses the weights specified by ADEPT. Based on ADEPT's updates, changing the medical_weight does things to the midpoint computation that we were not accounting for.  [unit tests removed]

I also parameterized the test class so that all of `MedicalUrgencyAlignmentADMComponent`'s tests are also run with `MedicalUrgencyAlignmentWeightedADMComponent` so that we don't have to duplicate those test cases. We  then also have the specialized tests for the weighted midpoint equations for affiliation and merit.

I understand if we don't want to merge this in, but thought I'd offer it.