### PR TITLE
Add capability for sub-kdma ICL DBs

### DIFF
--- a/align_system/algorithms/icl_adm_component.py
+++ b/align_system/algorithms/icl_adm_component.py
@@ -89,7 +89,7 @@ class ICLADMComponent(ADMComponent):
 
         icl_dialog_elements = {}
         icl_example_info = {}
-        
+
         for attribute in target_attributes:
             icl_dialog_elements[attribute.kdma] = []
             icl_example_info[attribute.kdma] = []
@@ -132,7 +132,8 @@ class ICLADMComponent(ADMComponent):
                 scenario_description_to_match=scenario_description,
                 prompt_to_match=prompt_to_match,
                 state_comparison=scenario_state,
-                actions=actions)
+                actions=actions,
+                sub_kdmas=[tgt_attr.kdma for tgt_attr in target_attributes if tgt_attr.kdma != attribute.kdma])
 
             for icl_sample in selected_icl_examples:
                 icl_dialog_elements[attribute.kdma].append(DialogElement(role='user',
@@ -141,7 +142,7 @@ class ICLADMComponent(ADMComponent):
                 icl_dialog_elements[attribute.kdma].append(DialogElement(role='assistant',
                                                          content=str(icl_sample['response']),
                                                          tags=['icl']))
-                
+
                 # Capture ICL example info for choice_info
                 icl_info = {
                     'prompt': icl_sample['prompt'],

--- a/align_system/configs/experiment/phase2_july_collab/pipeline_fewshot_comparative_regression_loo_specialized_icl.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/pipeline_fewshot_comparative_regression_loo_specialized_icl.yaml
@@ -1,0 +1,44 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+  - override /adm_component/alignment@adm.step_definitions.scalar_alignment: medical_urgency_weighted_scalar
+
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_fewshot_comp_reg_loo_specialized_icl"
+  domain: "p2triage"
+
+adm:
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          leave_one_out_strategy: 'scenario_description' # LOO - Remove for eval
+          datasets:
+            medical:
+              affiliation:
+                - /data/shared/samba/phase2_icl/July2025-AF-train_20250804.json
+                - /data/shared/samba/phase2_icl/July2025-MF-train_20250804.json
+                - /data/shared/samba/phase2_icl/July2025-SS-train_20250804.json
+              merit:
+                - /data/shared/samba/phase2_icl/July2025-AF-train_20250804.json
+                - /data/shared/samba/phase2_icl/July2025-MF-train_20250804.json
+                - /data/shared/samba/phase2_icl/July2025-SS-train_20250804.json
+              personal_safety: /data/shared/samba/phase2_icl/July2025-PS-train_20250804.json
+              search:
+                - /data/shared/samba/phase2_icl/July2025-AF-train_20250804.json
+                - /data/shared/samba/phase2_icl/July2025-MF-train_20250804.json
+                - /data/shared/samba/phase2_icl/July2025-SS-train_20250804.json
+            affiliation: /data/shared/samba/phase2_icl/July2025-AF-train_20250804.json
+            merit: /data/shared/samba/phase2_icl/July2025-MF-train_20250804.json
+            personal_safety: /data/shared/samba/phase2_icl/July2025-PS-train_20250804.json
+            search: /data/shared/samba/phase2_icl/July2025-SS-train_20250804.json
+    comparative_regression:
+      enable_caching: true
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true


### PR DESCRIPTION
Add sub-kdma ICL DB specification so one KDMAs DB can be based on another in the target (such as personal_safety affecting medical ICL examples)

Previous configs should still be compatible.