### PR TITLE
Add July 2025 RQ2 eval configs

### DIFF
--- a/align_system/configs/experiment/phase2_july_collab/pipeline_baseline_DeepSeek-R1-Distill-Qwen-7B_live_eval_test.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/pipeline_baseline_DeepSeek-R1-Distill-Qwen-7B_live_eval_test.yaml
@@ -8,10 +8,13 @@ interface:
   api_endpoint: "https://darpaitm.caci.com"
   session_type: eval
   training_session: null
-  username: "testrun-ALIGN-ADM-OutlinesBaseline-Mistral-7B-Instruct-v0.3"
+  username: "testrun-ALIGN-ADM-OutlinesBaseline-DeepSeek-R1-Distill-Qwen-7B"
   domain: "p2triage"
 
 adm:
+  structured_inference_engine:
+    model_name: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+
   step_definitions:
     outlines_baseline:
       scenario_description_template:
@@ -38,4 +41,4 @@ save_last_unstructured_state_per_scenario: true
 
 hydra:
   run:
-    dir: 'phase2_july_rq2_eval_live_test/baseline/${now:%Y-%m-%d__%H-%M-%S}'
+    dir: 'phase2_july_rq2_eval_live_test/baseline-DeepSeek-R1-Distill-Qwen-7B/${now:%Y-%m-%d__%H-%M-%S}'

--- a/align_system/configs/experiment/phase2_july_collab/pipeline_baseline_Meta-Llama-3-8B-Instruct_live_eval_test.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/pipeline_baseline_Meta-Llama-3-8B-Instruct_live_eval_test.yaml
@@ -8,10 +8,13 @@ interface:
   api_endpoint: "https://darpaitm.caci.com"
   session_type: eval
   training_session: null
-  username: "testrun-ALIGN-ADM-OutlinesBaseline-Mistral-7B-Instruct-v0.3"
+  username: "testrun-ALIGN-ADM-OutlinesBaseline-Meta-Llama-3-8B-Instruct"
   domain: "p2triage"
 
 adm:
+  structured_inference_engine:
+    model_name: meta-llama/Meta-Llama-3-8B-Instruct
+
   step_definitions:
     outlines_baseline:
       scenario_description_template:
@@ -38,4 +41,4 @@ save_last_unstructured_state_per_scenario: true
 
 hydra:
   run:
-    dir: 'phase2_july_rq2_eval_live_test/baseline/${now:%Y-%m-%d__%H-%M-%S}'
+    dir: 'phase2_july_rq2_eval_live_test/baseline-Meta-Llama-3-8B-Instruct/${now:%Y-%m-%d__%H-%M-%S}'

--- a/align_system/configs/experiment/phase2_july_collab/pipeline_baseline_Meta-Llama-3.2-3B-Instruct_live_eval_test.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/pipeline_baseline_Meta-Llama-3.2-3B-Instruct_live_eval_test.yaml
@@ -8,10 +8,13 @@ interface:
   api_endpoint: "https://darpaitm.caci.com"
   session_type: eval
   training_session: null
-  username: "testrun-ALIGN-ADM-OutlinesBaseline-Mistral-7B-Instruct-v0.3"
+  username: "testrun-ALIGN-ADM-OutlinesBaseline-Meta-Llama-3.2-3B-Instruct"
   domain: "p2triage"
 
 adm:
+  structured_inference_engine:
+    model_name: meta-llama/Llama-3.2-3B-Instruct
+
   step_definitions:
     outlines_baseline:
       scenario_description_template:
@@ -38,4 +41,4 @@ save_last_unstructured_state_per_scenario: true
 
 hydra:
   run:
-    dir: 'phase2_july_rq2_eval_live_test/baseline/${now:%Y-%m-%d__%H-%M-%S}'
+    dir: 'phase2_july_rq2_eval_live_test/baseline-Meta-Llama-3.2-3B-Instruct/${now:%Y-%m-%d__%H-%M-%S}'

--- a/align_system/configs/experiment/phase2_july_collab/pipeline_baseline_live_eval.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/pipeline_baseline_live_eval.yaml
@@ -38,4 +38,4 @@ save_last_unstructured_state_per_scenario: true
 
 hydra:
   run:
-    dir: 'phase2_july_eval_live/baseline/${now:%Y-%m-%d__%H-%M-%S}'
+    dir: 'phase2_july_rq2_eval_live/baseline/${now:%Y-%m-%d__%H-%M-%S}'

--- a/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_20icl_10samples_live_eval.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_20icl_10samples_live_eval.yaml
@@ -3,12 +3,13 @@ defaults:
   - override /adm: phase2_pipeline_fewshot_comparative_regression
   - override /interface: ta3
   - override /adm_component/alignment@adm.step_definitions.scalar_alignment: medical_urgency_weighted_scalar
+  - override /inference_engine@adm.structured_inference_engine: outlines_structured_multinomial
 
 interface:
   api_endpoint: "https://darpaitm.caci.com"
   session_type: eval
   training_session: null
-  username: "ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3"
+  username: "testrun_ALIGN-ADM-Ph2-ComparativeRegression-10Samples-Mistral-7B-Instruct-v0.3"
   domain: "p2triage"
 
 adm:
@@ -25,7 +26,8 @@ adm:
             search: /data/shared/samba/phase2_icl/July2025-SS-train_20250804.json
 
     comparative_regression:
-      enable_caching: true  
+      enable_caching: true
+      num_samples: 10
 
 apply_action_filtering: false
 force_determinism: true
@@ -34,5 +36,5 @@ save_last_unstructured_state_per_scenario: true
 
 hydra:
   run:
-    dir: 'phase2_july_rq2_eval_live/comp_reg_20icl/${now:%Y-%m-%d__%H-%M-%S}'
+    dir: 'phase2_july_rq2_eval_live_test/comp_reg_20icl_10samples/${now:%Y-%m-%d__%H-%M-%S}'
 

--- a/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_20icl_handpicked_live_eval.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_20icl_handpicked_live_eval.yaml
@@ -1,0 +1,38 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+  - override /adm_component/alignment@adm.step_definitions.scalar_alignment: medical_urgency_weighted_scalar
+
+interface:
+  api_endpoint: "https://darpaitm.caci.com"
+  session_type: eval
+  training_session: null
+  username: "testrun_ALIGN-ADM-Ph2-ComparativeRegression-HandPicked-Mistral-7B-Instruct-v0.3"
+  domain: "p2triage"
+
+adm:
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          datasets:
+            medical: /data/shared/samba/phase2_icl/medical_condition_icl.json
+            affiliation: /data/shared/samba/phase2_icl/July2025-AF-train_20250804.json
+            merit: /data/shared/samba/phase2_icl/July2025-MF-train_20250804.json
+            personal_safety: /data/shared/samba/phase2_icl/July2025-PS-train_20250804.json
+            search: /data/shared/samba/phase2_icl/July2025-SS-train_20250804.json
+
+    comparative_regression:
+      enable_caching: true  
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true
+save_last_unstructured_state_per_scenario: true
+
+hydra:
+  run:
+    dir: 'phase2_july_rq2_eval_live_test/comp_reg_20icl_handpicked_mu/${now:%Y-%m-%d__%H-%M-%S}'
+

--- a/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_20icl_live_eval.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_20icl_live_eval.yaml
@@ -1,0 +1,38 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+  - override /adm_component/alignment@adm.step_definitions.scalar_alignment: medical_urgency_weighted_scalar
+
+interface:
+  api_endpoint: "https://darpaitm.caci.com"
+  session_type: eval
+  training_session: null
+  username: "testrun_ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3"
+  domain: "p2triage"
+
+adm:
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          datasets:
+            medical: /data/shared/samba/phase2_icl/July2025-MU-train_20250804.json
+            affiliation: /data/shared/samba/phase2_icl/July2025-AF-train_20250804.json
+            merit: /data/shared/samba/phase2_icl/July2025-MF-train_20250804.json
+            personal_safety: /data/shared/samba/phase2_icl/July2025-PS-train_20250804.json
+            search: /data/shared/samba/phase2_icl/July2025-SS-train_20250804.json
+
+    comparative_regression:
+      enable_caching: true  
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true
+save_last_unstructured_state_per_scenario: true
+
+hydra:
+  run:
+    dir: 'phase2_july_rq2_eval_live_test/comp_reg_20icl/${now:%Y-%m-%d__%H-%M-%S}'
+

--- a/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_DeepSeek-R1-Distill-Qwen-7B_20icl_live_eval.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_DeepSeek-R1-Distill-Qwen-7B_20icl_live_eval.yaml
@@ -1,0 +1,41 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+  - override /adm_component/alignment@adm.step_definitions.scalar_alignment: medical_urgency_weighted_scalar
+
+interface:
+  api_endpoint: "https://darpaitm.caci.com"
+  session_type: eval
+  training_session: null
+  username: "testrun_ALIGN-ADM-Ph2-ComparativeRegression-DeepSeek-R1-Distill-Qwen-7B"
+  domain: "p2triage"
+
+adm:
+  structured_inference_engine:
+    model_name: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          datasets:
+            medical: /data/shared/samba/phase2_icl/July2025-MU-train_20250804.json
+            affiliation: /data/shared/samba/phase2_icl/July2025-AF-train_20250804.json
+            merit: /data/shared/samba/phase2_icl/July2025-MF-train_20250804.json
+            personal_safety: /data/shared/samba/phase2_icl/July2025-PS-train_20250804.json
+            search: /data/shared/samba/phase2_icl/July2025-SS-train_20250804.json
+
+    comparative_regression:
+      enable_caching: true  
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true
+save_last_unstructured_state_per_scenario: true
+
+hydra:
+  run:
+    dir: 'phase2_july_rq2_eval_live_test/comp_reg_20icl_DeepSeek-R1-Distill-Qwen-7B/${now:%Y-%m-%d__%H-%M-%S}'
+

--- a/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_Meta-Llama-3-8B-Instruct_20icl_live_eval.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_Meta-Llama-3-8B-Instruct_20icl_live_eval.yaml
@@ -1,0 +1,41 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+  - override /adm_component/alignment@adm.step_definitions.scalar_alignment: medical_urgency_weighted_scalar
+
+interface:
+  api_endpoint: "https://darpaitm.caci.com"
+  session_type: eval
+  training_session: null
+  username: "testrun_ALIGN-ADM-Ph2-ComparativeRegression-Meta-Llama-3-8B-Instruct"
+  domain: "p2triage"
+
+adm:
+  structured_inference_engine:
+    model_name: meta-llama/Meta-Llama-3-8B-Instruct
+
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          datasets:
+            medical: /data/shared/samba/phase2_icl/July2025-MU-train_20250804.json
+            affiliation: /data/shared/samba/phase2_icl/July2025-AF-train_20250804.json
+            merit: /data/shared/samba/phase2_icl/July2025-MF-train_20250804.json
+            personal_safety: /data/shared/samba/phase2_icl/July2025-PS-train_20250804.json
+            search: /data/shared/samba/phase2_icl/July2025-SS-train_20250804.json
+
+    comparative_regression:
+      enable_caching: true  
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true
+save_last_unstructured_state_per_scenario: true
+
+hydra:
+  run:
+    dir: 'phase2_july_rq2_eval_live_test/comp_reg_20icl_Meta-Llama-3-8B-Instruct/${now:%Y-%m-%d__%H-%M-%S}'
+

--- a/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_Meta-Llama-3.2-3B-Instruct_20icl_live_eval.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_Meta-Llama-3.2-3B-Instruct_20icl_live_eval.yaml
@@ -1,0 +1,41 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+  - override /adm_component/alignment@adm.step_definitions.scalar_alignment: medical_urgency_weighted_scalar
+
+interface:
+  api_endpoint: "https://darpaitm.caci.com"
+  session_type: eval
+  training_session: null
+  username: "testrun_ALIGN-ADM-Ph2-ComparativeRegression-Meta-Llama-3.2-3B-Instruct"
+  domain: "p2triage"
+
+adm:
+  structured_inference_engine:
+    model_name: meta-llama/Llama-3.2-3B-Instruct
+
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          datasets:
+            medical: /data/shared/samba/phase2_icl/July2025-MU-train_20250804.json
+            affiliation: /data/shared/samba/phase2_icl/July2025-AF-train_20250804.json
+            merit: /data/shared/samba/phase2_icl/July2025-MF-train_20250804.json
+            personal_safety: /data/shared/samba/phase2_icl/July2025-PS-train_20250804.json
+            search: /data/shared/samba/phase2_icl/July2025-SS-train_20250804.json
+
+    comparative_regression:
+      enable_caching: true  
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true
+save_last_unstructured_state_per_scenario: true
+
+hydra:
+  run:
+    dir: 'phase2_july_rq2_eval_live_test/comp_reg_20icl_Meta-Llama-3.2-3B-Instruct/${now:%Y-%m-%d__%H-%M-%S}'
+

--- a/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_bert_relevance_live_eval.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/rq2_pipeline_fewshot_comparative_regression_bert_relevance_live_eval.yaml
@@ -1,14 +1,15 @@
 # @package _global_
 defaults:
-  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /adm: phase2_pipeline_fewshot_comparative_regression_bert_relevance
   - override /interface: ta3
   - override /adm_component/alignment@adm.step_definitions.scalar_alignment: medical_urgency_weighted_scalar
+
 
 interface:
   api_endpoint: "https://darpaitm.caci.com"
   session_type: eval
   training_session: null
-  username: "ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3"
+  username: "ALIGN-ADM-Ph2-ComparativeRegression-BertRelevance-Mistral-7B-Instruct-v0.3"
   domain: "p2triage"
 
 adm:
@@ -25,7 +26,7 @@ adm:
             search: /data/shared/samba/phase2_icl/July2025-SS-train_20250804.json
 
     comparative_regression:
-      enable_caching: true  
+      enable_caching: true
 
 apply_action_filtering: false
 force_determinism: true
@@ -34,5 +35,4 @@ save_last_unstructured_state_per_scenario: true
 
 hydra:
   run:
-    dir: 'phase2_july_rq2_eval_live/comp_reg_20icl/${now:%Y-%m-%d__%H-%M-%S}'
-
+    dir: 'phase2_july_rq2_eval_live/comp_reg_20icl_multi_bert_relevance/${now:%Y-%m-%d__%H-%M-%S}'

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_20icl.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_20icl.yaml
@@ -1,0 +1,26 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+    
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_fewshot_comp_reg_test_20icl"
+  domain: "p2triage"
+
+adm:  
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          # LOO - Remove for eval
+          leave_one_out_strategy: 'scenario_description'
+
+    comparative_regression:
+      enable_caching: true
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_20icl_deepseek-r1-qwen-7b.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_20icl_deepseek-r1-qwen-7b.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+    
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_fewshot_comp_reg_test_20icl"
+  domain: "p2triage"
+
+adm:
+  structured_inference_engine:
+    model_name: deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
+  
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          # LOO - Remove for eval
+          leave_one_out_strategy: 'scenario_description'
+
+    comparative_regression:
+      enable_caching: true
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_20icl_gemma2-9b-it.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_20icl_gemma2-9b-it.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+    
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_fewshot_comp_reg_test_20icl"
+  domain: "p2triage"
+
+adm:
+  structured_inference_engine:
+    model_name: google/gemma-2-9b-it
+  
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          # LOO - Remove for eval
+          leave_one_out_strategy: 'scenario_description'
+
+    comparative_regression:
+      enable_caching: true
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_20icl_llama3-8b.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_20icl_llama3-8b.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+    
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_fewshot_comp_reg_test_20icl"
+  domain: "p2triage"
+
+adm:
+  structured_inference_engine:
+    model_name: meta-llama/Meta-Llama-3-8B-Instruct
+  
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          # LOO - Remove for eval
+          leave_one_out_strategy: 'scenario_description'
+
+    comparative_regression:
+      enable_caching: true
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_20icl_llama3.2-3b.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_20icl_llama3.2-3b.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+    
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_fewshot_comp_reg_test_20icl"
+  domain: "p2triage"
+
+adm:
+  structured_inference_engine:
+    model_name: meta-llama/Llama-3.2-3B-Instruct
+  
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          # LOO - Remove for eval
+          leave_one_out_strategy: 'scenario_description'
+
+    comparative_regression:
+      enable_caching: true
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true

--- a/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_20icl_llama3.3-70b.yaml
+++ b/align_system/configs/experiment/phase2_june_collab/pipeline_fewshot_comparative_regression_loo_20icl_llama3.3-70b.yaml
@@ -1,0 +1,31 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
+  - override /interface: ta3
+    
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_fewshot_comp_reg_test_20icl"
+  domain: "p2triage"
+
+adm:
+  structured_inference_engine:
+    model_name: meta-llama/Llama-3.3-70B-Instruct
+  
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          # LOO - Remove for eval
+          leave_one_out_strategy: 'scenario_description'
+          # For ablation experiment
+          least_similar_examples: True
+
+    comparative_regression:
+      enable_caching: true
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true


### PR DESCRIPTION
(In the future it's probably better to create a subdirectory inside of `phase2_july_collab` for each of `rq1` and `rq2`)