### PR TITLE
Experimental changes to allow choice swapping in the prompt

### DIFF
--- a/align_system/configs/adm/phase2_pipeline_fewshot_comparative_regression_swap_average.yaml
+++ b/align_system/configs/adm/phase2_pipeline_fewshot_comparative_regression_swap_average.yaml
@@ -1,0 +1,67 @@
+name: phase2_pipeline_zeroshot_comparative_regression_swap_average
+
+defaults:
+  # Import defaults into this namspace (adm) as @name, for further
+  # customization
+
+  # Shared variables / components
+  - /attribute@mu: medical_urgency
+  - /attribute@af: affiliation_focus
+  - /attribute@mf: merit_focus
+  - /attribute@ss: search_or_stay
+  - /attribute@ps: personal_safety
+  - /inference_engine@structured_inference_engine: outlines_structured_greedy
+  - /template/scenario_description@scenario_description_template: phase2
+  - /template/prompt@prompt_template: phase2_comparative_regression
+  - /template/output_schema@comparative_regression_choice_schema: phase2_comparative_regression_choice
+  # ADM components to be used in "steps"
+  - /adm_component/misc@step_definitions.format_choices: itm_format_choices
+  - /adm_component/icl@step_definitions.regression_icl: phase2_comparative
+  - /adm_component/regression@step_definitions.comparative_regression: phase2_comparative_no_template
+  - /adm_component/regression@step_definitions.comparative_regression_swap: phase2_comparative_no_template
+  - /adm_component/misc@step_definitions.regression_rule_based_correction: phase2_regression_rule_based_correction
+  - /adm_component/alignment@step_definitions.scalar_alignment: medical_urgency_scalar
+  - /adm_component/misc@step_definitions.justification_from_reasonings: justification_from_reasonings
+  - /adm_component/misc@step_definitions.ensure_chosen_action: ensure_chosen_action
+  - /adm_component/misc@step_definitions.populate_choice_info: populate_choice_info
+  # Use definitions in this file to override defaults defined above
+  - _self_
+
+attribute_definitions:
+  medical: ${adm.mu}
+  affiliation: ${adm.af}
+  merit: ${adm.mf}
+  search: ${adm.ss}
+  personal_safety: ${adm.ps}
+
+step_definitions:
+  regression_icl:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    attributes: ${adm.attribute_definitions}
+    prompt_template: ${ref:adm.prompt_template}
+
+  comparative_regression:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    prompt_template: ${ref:adm.prompt_template}
+    score_schema_template: ${adm.comparative_regression_choice_schema}
+
+  comparative_regression_swap:
+      scenario_description_template: ${ref:adm.scenario_description_template}
+      prompt_template: ${ref:adm.prompt_template}
+      score_schema_template: ${adm.comparative_regression_choice_schema}
+      reverse_choice_ordering: true
+
+instance:
+  _target_: align_system.algorithms.pipeline_adm.PipelineADM
+
+  steps:
+    # Reference the step instances we want to use in order
+    - ${ref:adm.step_definitions.format_choices}
+    - ${ref:adm.step_definitions.regression_icl}
+    - ${ref:adm.step_definitions.comparative_regression}
+    - ${ref:adm.step_definitions.comparative_regression_swap}
+    - ${ref:adm.step_definitions.regression_rule_based_correction}
+    - ${ref:adm.step_definitions.scalar_alignment}
+    - ${ref:adm.step_definitions.justification_from_reasonings}
+    - ${ref:adm.step_definitions.ensure_chosen_action}
+    - ${ref:adm.step_definitions.populate_choice_info}

--- a/align_system/configs/experiment/phase2_july_collab/pipeline_fewshot_comparative_regression_loo.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/pipeline_fewshot_comparative_regression_loo.yaml
@@ -24,7 +24,7 @@ adm:
             personal_safety: /data/shared/samba/phase2_icl/July2025-PS-train_20250715.json
             search: /data/shared/samba/phase2_icl/July2025-SS-train_20250715.json
     comparative_regression:
-      enable_caching: true  
+      enable_caching: true
 
 apply_action_filtering: false
 force_determinism: true


### PR DESCRIPTION
**DO NOT MERGE IN CURRENT STATE**

A bit of hackery here to be able to reverse choices in the prompt for comparative regression.  There's also functionality here to be able to run two passes of comparative regression, one reversed and one not-reversed and concatenate them together (gets averaged by the alignment function) but I'm not very confident in the implementation so don't necessarily want to merge as-is.

@jadie1 FYSA