### PR TITLE
Dev/choice ordering refactored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 * Added more details and examples to the pipeline ADM documentation
 * Added a new Phase 2 medical urgency alignment function (weighted) to reflect program collaboration updates
+* Added option for ICL example choice ordering - fixed, swapped, or random
+* Added option to swap choice ordering for comparative regression pipeline ADM component
+* Added capability to resolve pipeline ADM step output conflicts with a custom function
 
 ## 0.5.9
 

--- a/align_system/configs/adm/phase2_pipeline_fewshot_comparative_regression_swap_average.yaml
+++ b/align_system/configs/adm/phase2_pipeline_fewshot_comparative_regression_swap_average.yaml
@@ -1,0 +1,70 @@
+name: phase2_pipeline_zeroshot_comparative_regression_swap_average
+
+defaults:
+  # Import defaults into this namspace (adm) as @name, for further
+  # customization
+
+  # Shared variables / components
+  - /attribute@mu: medical_urgency
+  - /attribute@af: affiliation_focus
+  - /attribute@mf: merit_focus
+  - /attribute@ss: search_or_stay
+  - /attribute@ps: personal_safety
+  - /inference_engine@structured_inference_engine: outlines_structured_greedy
+  - /template/scenario_description@scenario_description_template: phase2
+  - /template/prompt@prompt_template: phase2_comparative_regression
+  - /template/output_schema@comparative_regression_choice_schema: phase2_comparative_regression_choice
+  # ADM components to be used in "steps"
+  - /adm_component/misc@step_definitions.format_choices: itm_format_choices
+  - /adm_component/icl@step_definitions.regression_icl: phase2_comparative
+  - /adm_component/regression@step_definitions.comparative_regression: phase2_comparative_no_template
+  - /adm_component/regression@step_definitions.comparative_regression_swap: phase2_comparative_no_template
+  - /adm_component/misc@step_definitions.regression_rule_based_correction: phase2_regression_rule_based_correction
+  - /adm_component/alignment@step_definitions.scalar_alignment: medical_urgency_scalar
+  - /adm_component/misc@step_definitions.justification_from_reasonings: justification_from_reasonings
+  - /adm_component/misc@step_definitions.ensure_chosen_action: ensure_chosen_action
+  - /adm_component/misc@step_definitions.populate_choice_info: populate_choice_info
+  # Use definitions in this file to override defaults defined above
+  - _self_
+
+attribute_definitions:
+  medical: ${adm.mu}
+  affiliation: ${adm.af}
+  merit: ${adm.mf}
+  search: ${adm.ss}
+  personal_safety: ${adm.ps}
+
+step_definitions:
+  regression_icl:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    attributes: ${adm.attribute_definitions}
+    prompt_template: ${ref:adm.prompt_template}
+
+  comparative_regression:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    prompt_template: ${ref:adm.prompt_template}
+    score_schema_template: ${adm.comparative_regression_choice_schema}
+
+  comparative_regression_swap:
+    scenario_description_template: ${ref:adm.scenario_description_template}
+    prompt_template: ${ref:adm.prompt_template}
+    score_schema_template: ${adm.comparative_regression_choice_schema}
+    reverse_choice_ordering: true
+    output_conflict_resolver:
+      _target_: align_system.algorithms.comparative_regression_adm_component.RegressionOutputsConflictResolver
+
+instance:
+  _target_: align_system.algorithms.pipeline_adm.PipelineADM
+
+  steps:
+    # Reference the step instances we want to use in order
+    - ${ref:adm.step_definitions.format_choices}
+    - ${ref:adm.step_definitions.regression_icl}
+    - ${ref:adm.step_definitions.comparative_regression}
+    - ${ref:adm.step_definitions.comparative_regression_swap}
+    - ${ref:adm.step_definitions.regression_rule_based_correction}
+    - ${ref:adm.step_definitions.scalar_alignment}
+    - ${ref:adm.step_definitions.justification_from_reasonings}
+    - ${ref:adm.step_definitions.ensure_chosen_action}
+    - ${ref:adm.step_definitions.populate_choice_info}
+

--- a/align_system/configs/adm_component/icl/phase2_comparative.yaml
+++ b/align_system/configs/adm_component/icl/phase2_comparative.yaml
@@ -15,6 +15,7 @@ icl_generator_partial:
     normalization: null
     sort_actions: true
     most_similar_first: false
+    choice_order: fixed
     datasets:
       medical: /data/shared/samba/phase2_icl/June2025-MU-train_20250602.json
       affiliation: /data/shared/samba/phase2_icl/June2025-AF-train_20250523.json

--- a/align_system/configs/experiment/phase2_july_collab/pipeline_fewshot_comparative_regression_loo_swap_average.yaml
+++ b/align_system/configs/experiment/phase2_july_collab/pipeline_fewshot_comparative_regression_loo_swap_average.yaml
@@ -1,0 +1,35 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression_swap_average
+  - override /interface: ta3
+  - override /adm_component/alignment@adm.step_definitions.scalar_alignment: medical_urgency_weighted_scalar
+
+interface:
+  session_type: adept
+  training_session: full
+  username: "pipeline_fewshot_comp_reg_loo"
+  domain: "p2triage"
+
+adm:
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          leave_one_out_strategy: 'scenario_description' # LOO - Remove for eval
+          datasets:
+            medical: /data/shared/samba/phase2_icl/July2025-MU-train_20250804.json
+            affiliation: /data/shared/samba/phase2_icl/July2025-AF-train_20250804.json
+            merit: /data/shared/samba/phase2_icl/July2025-MF-train_20250804.json
+            personal_safety: /data/shared/samba/phase2_icl/July2025-PS-train_20250804.json
+            search: /data/shared/samba/phase2_icl/July2025-SS-train_20250804.json
+
+    comparative_regression:
+      enable_caching: true
+
+    comparative_regression_swap:
+      enable_caching: true
+
+apply_action_filtering: false
+force_determinism: true
+align_to_target: true

--- a/align_system/utils/incontext_utils.py
+++ b/align_system/utils/incontext_utils.py
@@ -213,6 +213,7 @@ class IncontextExampleGenerator(object, metaclass=ABCMeta):
             {kdma:[{state, actions, choices, kdma_values}, ...], ...}
         '''
         incontext_data = {}
+        choice_order = self.incontext_settings.get('choice_order', 'fixed')
         # For each kdma
         for target_kdma in self.target_kdmas:
             sys_kdma_name = target_kdma['kdma']
@@ -241,7 +242,11 @@ class IncontextExampleGenerator(object, metaclass=ABCMeta):
                         combined = list(zip(actions, labels, reasonings))
                         combined_sorted = sorted(combined, key=lambda x: x[0].unstructured)
                         actions, labels, reasonings = zip(*combined_sorted)
-
+                    # Swap choice order if requested
+                    if choice_order == "swapped" or (choice_order == "random" and random.choice([0, 1])):
+                        combined = list(zip(actions, labels, reasonings))
+                        combined_sorted = sorted(combined, key=lambda x: x[0].unstructured, reverse=True)
+                        actions, labels, reasonings = zip(*combined_sorted)
                     # Get choices
                     choices = adm_utils.format_choices(
                         [a.unstructured for a in actions],


### PR DESCRIPTION
Supplants #239 and #236.  This PR adds options to swap the ordering of choices for both the comparative regression and ICL examples (randomizing also a choice for ICL).  To accommodate running both swapped and not swapped and combining those regressed values (to be averaged downstream), there's a new hook added for an `output_conflict_resolver` function for each step that can specify how outputs should be handled if they already exist in the pipeline's `working_output` (by default new values replace old).