### PR TITLE
Open World Patient Ranking Pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 * Added `MultinomialRandomEffectsModelAlignmentADMComponent` for binomial/trinomial alignment based on ADEPT's latest guidance
+* Added `TournamentRandomEffectsModelAlignmentADMComponent`, a tournament-style version of the random effects alignment function
+  (note this is still not multi-kdma)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 * Added `MultinomialRandomEffectsModelAlignmentADMComponent` for binomial/trinomial alignment based on ADEPT's latest guidance
 * Added `TournamentRandomEffectsModelAlignmentADMComponent`, a tournament-style version of the random effects alignment function
   (note this is still not multi-kdma)
+* Added several new components for "Open World" experimentation: `OWFormatChoicesADMComponent` extracts relevant characters such that
+  the ADM chooses a character instead of an action, `OWChoiceToActionADMComponent` maps a character selection back to an actual action,
+  `OWActionParameterCompletionADMComponent` ensures all required parameters are filled in,`OWTaggingAdjustmentADMComponent` applies
+  heuristics to indirectly affect tag choice by the alignment target based on unaligned vs aligned patient ranking, and
+  `OWRandomParameterCompletionADMComponent` was added so that the random ADM can function in this environment for smoketests.
+* Added a new driver for "Open World" experimentation: `ITMOpenWorldDriver`. Note that while the name implies the ADM can operate in
+  an unconstrained environment, "Open World" has a slightly more restricted meaning for the program and assumes a specific scenario
+  structure.
 
 ### Fixed
 

--- a/align_system/algorithms/alignment_adm_component.py
+++ b/align_system/algorithms/alignment_adm_component.py
@@ -58,7 +58,7 @@ class AlignmentADMComponent(ADMComponent):
 
 class MedicalOnlyAlignmentADMComponent(ADMComponent):
     def run_returns(self):
-        return ('chosen_choice', 'best_sample_idx')
+        return ('chosen_choice', 'best_sample_idx', 'medical_urgency_info')
 
     def run(
         self,
@@ -111,7 +111,11 @@ class MedicalOnlyAlignmentADMComponent(ADMComponent):
 
             return best_idx
 
-        return (selected_choice, _get_best_sample_idx(max_urg, attribute_prediction_scores[selected_choice]))
+        return (
+            selected_choice,
+            _get_best_sample_idx(max_urg, attribute_prediction_scores[selected_choice]),
+            med_urg,
+        )
 
 
 def _handle_single_value(predictions):

--- a/align_system/algorithms/alignment_adm_component.py
+++ b/align_system/algorithms/alignment_adm_component.py
@@ -357,21 +357,14 @@ class RandomEffectsModelAlignmentADMComponent(ADMComponent):
         y_ij = intercept + medical_weight*medical_delta + attr_weight*attr_score
         return math.exp(y_ij) / (1 + math.exp(y_ij))
 
-    def run(
+    def _preproccess_predictions(
         self,
         attribute_prediction_scores,
         alignment_target,
         attribute_relevance=None,
     ):
         """
-        Align using ADEPT's random effects model theory
-
-        attribute_prediction_scores: dict[str, dict[str, float | list[float]]]
-            Dictionary of choices mapped to KMDA value predictions, including medical
-            urgency prediction
-        alignment_target: alignment target info
-        attribute_relevance: dict[str, float | list[float]]
-            Dictionary of probe level KDMA relevance predictions
+        Preprocess run input arguments for future usage, while also completing some input validation.
         """
         if alignment_target is None:
             raise RuntimeError(
@@ -384,8 +377,6 @@ class RandomEffectsModelAlignmentADMComponent(ADMComponent):
         target_kdmas = [dict(t) for t in target_kdmas]
 
         choices = list(attribute_prediction_scores.keys())
-        if len(choices) != 2:
-            raise NotImplementedError("This alignment function has not yet been implemented for !=2 choices")
 
         # Compute averages of predicted values
         predictions = []
@@ -412,7 +403,30 @@ class RandomEffectsModelAlignmentADMComponent(ADMComponent):
         if len(relevant_kdmas) != 1:
             raise RuntimeError("This alignment function can only be used when 1 attribute is relevant")
 
-        # Guaranteed to only have 2 choices at this point due to earlier checks
+        return target_kdmas, choices, predictions, probe_relevance, relevant_kdmas
+
+    def run(
+        self,
+        attribute_prediction_scores,
+        alignment_target,
+        attribute_relevance=None,
+    ):
+        """
+        Align using ADEPT's random effects model theory
+
+        attribute_prediction_scores: dict[str, dict[str, float | list[float]]]
+            Dictionary of choices mapped to KMDA value predictions, including medical
+            urgency prediction
+        alignment_target: alignment target info
+        attribute_relevance: dict[str, float | list[float]]
+            Dictionary of probe level KDMA relevance predictions
+        """
+        target_kdmas, choices, predictions, probe_relevance, relevant_kdmas = self._preproccess_predictions(attribute_prediction_scores, alignment_target, attribute_relevance)
+
+        # This alignment function only works for binary (2-choice probes)
+        if len(choices) != 2:
+            raise NotImplementedError("This alignment function has not yet been implemented for !=2 choices")
+
         opt_a, opt_b = predictions
 
         for target_kdma in target_kdmas:
@@ -629,3 +643,110 @@ class MultinomialRandomEffectsModelAlignmentADMComponent(ADMComponent):
             selected_choice_idx = np.argmax(probs)
 
             return predictions[selected_choice_idx]["choice"], best_sample_idx, alignment_info
+
+
+class TournamentRandomEffectsModelAlignmentADMComponent(RandomEffectsModelAlignmentADMComponent):
+    def __init__(
+        self,
+        attributes=None
+    ):
+        super().__init__(attributes)
+
+    def _log_odds(self, p, eps=1e-12):
+        p = np.clip(p, eps, 1-eps)  # avoid division by 0 or log(0)
+        log_odds = np.log(p / (1 - p))
+        np.fill_diagonal(log_odds, 0)  # explicitly set diagonal to 0 so that it doesn't affect later computations
+        return log_odds
+
+    def _stable_softmax(self, scores):
+        e_scores = np.exp(scores - np.max(scores))  # Subtracting the max for numerical stability
+        return e_scores / e_scores.sum(axis=0)
+
+    def _composite_probs(self, p_matrix):
+        """Combines sub-problem probabities into per-choice composite probabilities"""
+        log_odds = self._log_odds(p_matrix)
+        scores = np.sum(log_odds, axis=1)
+        return self._stable_softmax(scores)
+
+    def run(
+        self,
+        attribute_prediction_scores,
+        alignment_target,
+        attribute_relevance=None,
+    ):
+        """
+        Align using a tournament-style expansion of ADEPT's random effects model theory
+
+        attribute_prediction_scores: dict[str, dict[str, float | list[float]]]
+            Dictionary of choices mapped to KMDA value predictions, including medical
+            urgency prediction
+        alignment_target: alignment target info
+        attribute_relevance: dict[str, float | list[float]]
+            Dictionary of probe level KDMA relevance predictions
+        """
+        target_kdmas, choices, predictions, probe_relevance, relevant_kdmas = self._preproccess_predictions(attribute_prediction_scores, alignment_target, attribute_relevance)
+
+        # Only one option, decision always has to be the same
+        if len(choices) == 1:
+            return (
+                predictions[0]["choice"],
+                0,  # TODO: best sample index
+                {
+                    "source": type(self).__name__,
+                    "p_choices": np.ones((1,)),
+                },
+            )
+
+        # We iterate to find the relevant KDMA, this isn't multi-kdma yet (raised in preprocess)
+        for target_kdma in target_kdmas:
+            kdma = target_kdma["kdma"]
+            if kdma != relevant_kdmas[0]:
+                continue
+
+            intercept = None
+            medical_weight = None
+            attr_weight = None
+            if target_kdma["parameters"] is not None:
+                for param in target_kdma["parameters"]:
+                    if param["name"] == "intercept":
+                        intercept = param["value"]
+                    if param["name"] == "medical_weight":
+                        medical_weight = param["value"]
+                    if param["name"] == "attr_weight":
+                        attr_weight = param["value"]
+            if intercept is None or medical_weight is None or attr_weight is None:
+                raise RuntimeError("This alignment function requires an intercept, medical weight, and attr weight")
+
+            # Loop over options pairwise
+            p_matrix = np.ones((len(choices), len(choices)))
+            for choice_idx_a, opt_a in enumerate(predictions[:-1]):
+                for choice_idx_b, opt_b in enumerate(predictions[choice_idx_a+1:]):
+                    raw_medical_delta = opt_a[med_urg_str] - opt_b[med_urg_str]
+
+                    # Choices should be sorted by descending medical need due to model assumptions
+                    flip_order = False
+                    if raw_medical_delta < 0:
+                        flip_order = True
+                        raw_medical_delta *= -1
+                    primary, secondary = (opt_a, opt_b) if not flip_order else (opt_b, opt_a)
+                    raw_attr_score = secondary[kdma] if kdma == "search" else primary[kdma]
+
+                    p_choose_primary = self._compute_p_choose_a(
+                        kdma, intercept, medical_weight, attr_weight, raw_medical_delta, raw_attr_score)
+
+                    p_matrix[choice_idx_a][choice_idx_b] = p_choose_primary if not flip_order else 1 - p_choose_primary
+                    p_matrix[choice_idx_b][choice_idx_a] = 1 - p_choose_primary if not flip_order else p_choose_primary
+
+            p_choices = self._composite_probs(p_matrix)
+
+            # TODO: Figure out what it means to be the best prediction for this alignment function
+            best_sample_idx = 0
+
+            alignment_info = {
+                "source": type(self).__name__,
+                "p_choices": p_choices.tolist(),
+            }
+
+            max_idx = np.argmax(p_choices)
+
+            return (predictions[max_idx]["choice"], best_sample_idx, alignment_info)

--- a/align_system/algorithms/alignment_adm_component.py
+++ b/align_system/algorithms/alignment_adm_component.py
@@ -668,6 +668,9 @@ class TournamentRandomEffectsModelAlignmentADMComponent(RandomEffectsModelAlignm
         scores = np.sum(log_odds, axis=1)
         return self._stable_softmax(scores)
 
+    def run_returns(self):
+        return ('chosen_choice', 'best_sample_idx', 'p_choices', 'alignment_info')
+
     def run(
         self,
         attribute_prediction_scores,
@@ -688,12 +691,14 @@ class TournamentRandomEffectsModelAlignmentADMComponent(RandomEffectsModelAlignm
 
         # Only one option, decision always has to be the same
         if len(choices) == 1:
+            p_choices = np.ones((1,)).tolist()
             return (
                 predictions[0]["choice"],
                 0,  # TODO: best sample index
+                p_choices,
                 {
                     "source": type(self).__name__,
-                    "p_choices": np.ones((1,)),
+                    "p_choices": p_choices,
                 },
             )
 
@@ -742,11 +747,14 @@ class TournamentRandomEffectsModelAlignmentADMComponent(RandomEffectsModelAlignm
             # TODO: Figure out what it means to be the best prediction for this alignment function
             best_sample_idx = 0
 
+            max_idx = np.argmax(p_choices)
+            p_choices = p_choices.tolist()
+
             alignment_info = {
                 "source": type(self).__name__,
-                "p_choices": p_choices.tolist(),
+                "p_choices": p_choices,
             }
 
-            max_idx = np.argmax(p_choices)
 
-            return (predictions[max_idx]["choice"], best_sample_idx, alignment_info)
+
+            return (predictions[max_idx]["choice"], best_sample_idx, p_choices, alignment_info)

--- a/align_system/algorithms/alignment_adm_component.py
+++ b/align_system/algorithms/alignment_adm_component.py
@@ -675,6 +675,49 @@ class TournamentRandomEffectsModelAlignmentADMComponent(RandomEffectsModelAlignm
     def run_returns(self):
         return ('chosen_choice', 'best_sample_idx', 'p_choices', 'alignment_info')
 
+    def _compute_p_choose_a(
+        self, kdma, intercept, medical_weight, attr_weight, opt_a, opt_b,
+    ):
+        # Provided by ADEPT 2025-12-12
+        # MF updated 2026-01-21
+        scaling = {
+                "affiliation": {
+                    med_urg_str: [0.589, 0.330],
+                    attr_str: [0.703, 0.365],
+                },
+                "merit": {
+                    med_urg_str: [0.576, 0.339],
+                    attr_str: [0.671, 0.381],
+                },
+                "personal_safety": {
+                    med_urg_str: [0.228, 0.287],
+                    attr_str: [0.777, 0.309],
+                },
+                "search": {
+                    med_urg_str: [0.263, 0.365],
+                    attr_str: [0.286, 0.325],
+                },
+            }
+        if kdma not in scaling:
+            raise RuntimeError(f"No z-scaling values provided for {kdma}")
+        scaling = scaling[kdma]
+
+        def _apply_z_scaling(key, raw_value):
+            return (raw_value - scaling[key][0]) / scaling[key][1]
+
+        # Apply z-scaling
+        a_med = _apply_z_scaling(med_urg_str, opt_a[med_urg_str])
+        a_attr = _apply_z_scaling(attr_str, opt_a[kdma])
+        b_med = _apply_z_scaling(med_urg_str, opt_b[med_urg_str])
+        b_attr = _apply_z_scaling(attr_str, opt_b[kdma])
+
+        medical_delta = a_med - b_med
+        attr_score = a_attr - b_attr
+
+        # Compute p_choose_a
+        y_ij = intercept + medical_weight*medical_delta + attr_weight*attr_score
+        return math.exp(y_ij) / (1 + math.exp(y_ij))
+
     def run(
         self,
         attribute_prediction_scores,
@@ -738,10 +781,9 @@ class TournamentRandomEffectsModelAlignmentADMComponent(RandomEffectsModelAlignm
                         flip_order = True
                         raw_medical_delta *= -1
                     primary, secondary = (opt_a, opt_b) if not flip_order else (opt_b, opt_a)
-                    raw_attr_score = secondary[kdma] if kdma == "search" else primary[kdma]
 
                     p_choose_primary = self._compute_p_choose_a(
-                        kdma, intercept, medical_weight, attr_weight, raw_medical_delta, raw_attr_score)
+                        kdma, intercept, medical_weight, attr_weight, primary, secondary)
 
                     p_matrix[choice_idx_a][choice_idx_b] = p_choose_primary if not flip_order else 1 - p_choose_primary
                     p_matrix[choice_idx_b][choice_idx_a] = 1 - p_choose_primary if not flip_order else p_choose_primary

--- a/align_system/algorithms/open_world_components.py
+++ b/align_system/algorithms/open_world_components.py
@@ -1,0 +1,211 @@
+import json
+from collections import defaultdict
+from rich.highlighter import JSONHighlighter
+from swagger_client.models import ActionTypeEnum, CharacterTagEnum
+
+from align_system.algorithms.abstracts import ADMComponent
+from align_system.algorithms.outlines_baseline_adm_component import OutlinesBaselineADMComponent
+from align_system.data_models.dialog import DialogElement
+from align_system.prompt_engineering.outlines_prompts import character_choice_json_schema, tag_choice_json_schema
+from align_system.prompt_engineering.ow_prompts import FollowupClarifyCharacterPrompt, FollowupClarifyTagPrompt
+from align_system.utils import call_with_coerced_args, logging, get_swagger_class_enum_values
+
+log = logging.getLogger(__name__)
+JSON_HIGHLIGHTER = JSONHighlighter()
+
+
+class OWFormatChoicesADMComponent(ADMComponent):
+    def run_returns(self):
+        return ('choices', 'choice_to_action_mapping')
+
+    def run(self, scenario_state, actions):
+        choice_to_action_mapping = defaultdict(list)
+        choices = []  # Not a set to preserve action order
+
+        non_character_action_types = [
+            ActionTypeEnum.END_SCENE
+        ]
+
+        character_to_choice = {
+            c.id: f"{c.name}: {c.unstructured}"
+            for c in scenario_state.characters
+        }
+
+        def _add_choice(choice, action):
+            """Add choice to list of choices (if needed), add action to mapping."""
+            if choice not in choices:
+                choices.append(choice)
+            choice_to_action_mapping[choice].append(action)
+
+        # Add each character/non-character action to list of choices and
+        # construct a choice to action mapping for later use
+        for a in actions:
+            if a.character_id is not None:
+                _add_choice(character_to_choice[a.character_id], a)
+            elif a.action_type in non_character_action_types:
+                _add_choice(a.unstructured, a)
+            else:  # No character specified, add all characters
+                for c in scenario_state.characters:
+                    _add_choice(character_to_choice[c.id], a)
+
+        return choices, choice_to_action_mapping
+
+
+class OWChoiceToActionADMComponent(OutlinesBaselineADMComponent):
+    def run_returns(self):
+        return ('chosen_action', 'choice_to_action_dialog')
+
+    def run(
+        self,
+        scenario_state,
+        chosen_choice,
+        choice_to_action_mapping,
+        justification=None,
+    ):
+        if chosen_choice not in choice_to_action_mapping:
+            raise ValueError(f"Choice ({chosen_choice}) not found in choice_to_action_mapping")
+
+        choice_to_action_dialog = None
+        possible_actions = choice_to_action_mapping[chosen_choice]
+
+        if len(possible_actions) == 0:
+            raise ValueError(f"Choice ({chosen_choice}) has no possible actions")
+        elif len(possible_actions) == 1:  # Single action, choose that
+            chosen_action = possible_actions[0]
+        else:
+            choices = [a.unstructured for a in possible_actions]
+            chosen_choice, justification, choice_to_action_dialog = super().run(scenario_state, choices)
+
+            chosen_action = possible_actions[choices.index(chosen_choice)]
+
+        if (hasattr(chosen_action, 'justification')
+                and chosen_action.justification is None
+                and justification is not None):
+            if isinstance(chosen_action, tuple) and hasattr(chosen_action, "_replace"):
+                chosen_action = chosen_action._replace(justification=justification)
+            else:
+                chosen_action.justification = justification
+
+        return chosen_action, choice_to_action_dialog
+
+
+class OWActionParameterCompletionADMComponent(ADMComponent):
+    def __init__(
+        self,
+        structured_inference_engine,
+        scenario_description_template,
+        system_prompt=None,
+    ):
+        self.structured_inference_engine = structured_inference_engine
+        self.scenario_description_template = scenario_description_template
+        self.system_prompt = system_prompt
+
+        self.followup_character_prompt = FollowupClarifyCharacterPrompt()
+        self.followup_tag_prompt = FollowupClarifyTagPrompt()
+
+    def run_returns(self):
+        return ('chosen_action', 'action_parameter_completion_dialog')
+
+    def run(
+        self,
+        scenario_state,
+        chosen_action,
+    ):
+        action_parameter_completion_dialog = {}
+
+        # Action requires a character ID
+        if chosen_action.action_type in {'TREAT_PATIENT',
+                                         ActionTypeEnum.MOVE_TO_EVAC,
+                                         ActionTypeEnum.TAG_CHARACTER}:
+            if chosen_action.character_id is None:
+                dialog = []
+                if self.system_prompt is not None:
+                    dialog.append(DialogElement(role='system', content=self.system_prompt()))
+
+                scenario_description = call_with_coerced_args(
+                    self.scenario_description_template,
+                    {'scenario_state': scenario_state})
+
+                dialog.append(
+                    DialogElement(
+                        role='user',
+                        content=self.followup_character_prompt(scenario_description, chosen_action)
+                    )
+                )
+
+                dialog_prompt = self.structured_inference_engine.dialog_to_prompt(dialog)
+                character_names = [c.name for c in scenario_state.characters]
+                selected_character = self.structured_inference_engine.run_inference(
+                    dialog_prompt,
+                    character_choice_json_schema(json.dumps(character_names)),
+                )
+                selected_character_idx = character_names.index(selected_character['character_choice'])
+
+                chosen_action.character_id = scenario_state.characters[selected_character_idx].id
+
+                justification = selected_character["brief_reasoning"]
+                if isinstance(chosen_action, tuple) and hasattr(chosen_action, "_replace"):
+                    chosen_action = chosen_action._replace(justification=justification)
+                else:
+                    chosen_action.justification = justification
+
+                action_parameter_completion_dialog["character_id"] = dialog
+
+        # Tagging requires tag type
+        if chosen_action.action_type == ActionTypeEnum.TAG_CHARACTER:
+            if chosen_action.parameters is None:
+                chosen_action.parameters = {}
+
+            if 'category' not in chosen_action.parameters:
+                dialog = []
+                if self.system_prompt is not None:
+                    dialog.append(DialogElement(role='system', content=self.system_prompt()))
+
+                chosen_character = None
+                for c in scenario_state.characters:
+                    if c.id == chosen_action.character_id:
+                        chosen_character = c
+                        break
+
+                dialog.append(
+                    DialogElement(role='user', content=self.followup_tag_prompt(chosen_character))
+                )
+
+                dialog_prompt = self.structured_inference_engine.dialog_to_prompt(dialog)
+                valid_tags = get_swagger_class_enum_values(CharacterTagEnum)
+                selected_tag = self.structured_inference_engine.run_inference(
+                    dialog_prompt,
+                    tag_choice_json_schema(json.dumps(valid_tags))
+                )
+
+                chosen_action.parameters['category'] = selected_tag["triage_tag"]
+
+                justification = selected_tag["detailed_reasoning"]
+                if isinstance(chosen_action, tuple) and hasattr(chosen_action, "_replace"):
+                    chosen_action = chosen_action._replace(justification=justification)
+                else:
+                    chosen_action.justification = justification
+
+                action_parameter_completion_dialog["tag"] = dialog
+
+        return chosen_action, action_parameter_completion_dialog
+
+
+class OWTaggingAdjustmentADMComponent(ADMComponent):
+    def run_returns(self):
+        return ('chosen_action')
+
+    def run(
+        self,
+        scenario_state,
+        chosen_action,
+        choices,
+        choice_to_action_mapping,
+        attribute_prediction_scores,
+        p_choices,
+    ):
+        if chosen_action.action_type == ActionTypeEnum.TAG_CHARACTER:
+            # TODO: Affect tagging behavior
+            pass
+
+        return chosen_action

--- a/align_system/algorithms/open_world_components.py
+++ b/align_system/algorithms/open_world_components.py
@@ -5,6 +5,7 @@ from swagger_client.models import ActionTypeEnum, CharacterTagEnum
 
 from align_system.algorithms.abstracts import ADMComponent
 from align_system.algorithms.outlines_baseline_adm_component import OutlinesBaselineADMComponent
+from align_system.algorithms.alignment_adm_component import MedicalOnlyAlignmentADMComponent
 from align_system.data_models.dialog import DialogElement
 from align_system.prompt_engineering.outlines_prompts import character_choice_json_schema, tag_choice_json_schema
 from align_system.prompt_engineering.ow_prompts import FollowupClarifyCharacterPrompt, FollowupClarifyTagPrompt
@@ -134,11 +135,17 @@ class OWActionParameterCompletionADMComponent(ADMComponent):
                 )
 
                 dialog_prompt = self.structured_inference_engine.dialog_to_prompt(dialog)
+                log.info("[bold]*CHARACTER FOLLOWUP PROMPT*[/bold]", extra={"markup": True})
+                log.info(dialog_prompt)
+
                 character_names = [c.name for c in scenario_state.characters]
                 selected_character = self.structured_inference_engine.run_inference(
                     dialog_prompt,
                     character_choice_json_schema(json.dumps(character_names)),
                 )
+                log.info("[bold]*CHARACTER FOLLOWUP RESPONSE*[/bold]", extra={"markup": True})
+                log.info(selected_character, extra={"highlighter": JSON_HIGHLIGHTER})
+
                 selected_character_idx = character_names.index(selected_character['character_choice'])
 
                 chosen_action.character_id = scenario_state.characters[selected_character_idx].id
@@ -172,11 +179,16 @@ class OWActionParameterCompletionADMComponent(ADMComponent):
                 )
 
                 dialog_prompt = self.structured_inference_engine.dialog_to_prompt(dialog)
+                log.info("[bold]*TAGGING FOLLOWUP PROMPT*[/bold]", extra={"markup": True})
+                log.info(dialog_prompt)
+
                 valid_tags = get_swagger_class_enum_values(CharacterTagEnum)
                 selected_tag = self.structured_inference_engine.run_inference(
                     dialog_prompt,
                     tag_choice_json_schema(json.dumps(valid_tags))
                 )
+                log.info("[bold]*TAGGING FOLLOWUP RESPONSE*[/bold]", extra={"markup": True})
+                log.info(selected_tag, extra={"highlighter": JSON_HIGHLIGHTER})
 
                 chosen_action.parameters['category'] = selected_tag["triage_tag"]
 
@@ -191,21 +203,83 @@ class OWActionParameterCompletionADMComponent(ADMComponent):
         return chosen_action, action_parameter_completion_dialog
 
 
-class OWTaggingAdjustmentADMComponent(ADMComponent):
+class OWTaggingAdjustmentADMComponent(MedicalOnlyAlignmentADMComponent):
+    def __init__(self, increase_priority_threshold=0.55, decrease_priority_threshold=0.80):
+        self.increase_priority_threshold = increase_priority_threshold
+        self.decrease_priority_threshold = decrease_priority_threshold
     def run_returns(self):
         return ('chosen_action')
 
     def run(
         self,
         scenario_state,
-        chosen_action,
         choices,
-        choice_to_action_mapping,
+        chosen_choice,
+        chosen_action,
         attribute_prediction_scores,
         p_choices,
     ):
         if chosen_action.action_type == ActionTypeEnum.TAG_CHARACTER:
-            # TODO: Affect tagging behavior
-            pass
+            tag_order = [
+                CharacterTagEnum.IMMEDIATE,
+                CharacterTagEnum.DELAYED,
+                CharacterTagEnum.MINIMAL,
+                CharacterTagEnum.EXPECTANT,
+            ]
+
+            # Original assigned tag
+            assigned_tag_idx = tag_order.index(chosen_action.parameters['category'])
+
+            # Identify which index corresponds to this action
+            choice_idx = choices.index(chosen_choice)
+
+            def _get_sorted_ranking(ratings, descending=True):
+                indexed_ratings = list(enumerate(ratings))
+                indexed_ratings.sort(key=lambda x: x[1], reverse=descending)
+                for i, (original_index, rating) in enumerate(indexed_ratings):
+                    if original_index == choice_idx:
+                        return i  # new ranking
+
+            # Get ranking based on alignment
+            aligned_ranking = _get_sorted_ranking(p_choices, descending=True)
+
+            # Get medical only ranking
+            _, _, med_urg_info = super().run(attribute_prediction_scores)
+            med_urg_choices = [med_urg_info[choice] for choice in choices]
+            medical_ranking = _get_sorted_ranking(med_urg_choices, descending=True)
+
+            # How much did alignment diverge from the medical ranking
+            ranking_delta = medical_ranking - aligned_ranking
+            percent_change = ranking_delta / len(choices)
+
+            # What tags have been given out already
+            tag_counts = defaultdict(int)
+            for c in scenario_state.characters:
+                if c.tag is not None:
+                    tag_counts[c.tag] += 1
+            lowest_priority_given_idx = None
+            for i in range(len(tag_order)-2, -1, -1):  # Don't consider black tags, order is slightly weird
+                if tag_counts[tag_order[i]] > 0:
+                    lowest_priority_given_idx = i
+                    break
+
+            adjusted_tag_idx = assigned_tag_idx
+            if percent_change > self.increase_priority_threshold:
+                adjusted_tag_idx = max(0, adjusted_tag_idx - 1)
+            if percent_change < -self.decrease_priority_threshold:
+                adjusted_tag_idx = min(len(tag_order)-1, adjusted_tag_idx + 1)
+            # Have already given out lower priority tags, heuristic only works when omniscient
+            if lowest_priority_given_idx is not None and lowest_priority_given_idx > assigned_tag_idx:
+                adjusted_tag_idx = lowest_priority_given_idx
+
+            chosen_action.parameters['category'] = tag_order[adjusted_tag_idx]
+            # TODO: Update justification?
+
+            if assigned_tag_idx != adjusted_tag_idx:
+                log.info("[bold]*TAG ADJUSTMENT*[/bold]", extra={"markup": True})
+                log.info(
+                    "Original: {}, Adjusted: {}".format(tag_order[assigned_tag_idx], tag_order[adjusted_tag_idx]),
+                    extra={"highlighter": JSON_HIGHLIGHTER}
+                )
 
         return chosen_action

--- a/align_system/algorithms/random_adm_component.py
+++ b/align_system/algorithms/random_adm_component.py
@@ -67,6 +67,9 @@ class RandomParameterCompletionADMComponent(ADMComponent):
 
         # Action requires an aid ID
         elif chosen_action.action_type == ActionTypeEnum.MOVE_TO_EVAC:
+            if chosen_action.parameters is None:
+                chosen_action.parameters = {}
+
             if "aid_id" not in chosen_action.parameters:
                 chosen_action.parameters["aid_id"] = random.choice([
                     aid.id
@@ -74,6 +77,44 @@ class RandomParameterCompletionADMComponent(ADMComponent):
                 ])
 
         # Required since Dry Run Evaluation
+        chosen_action.justification = "Random choice"
+
+        return chosen_action
+
+
+class OWRandomParameterCompletionADMComponent(ADMComponent):
+    def run_returns(self):
+        return 'chosen_action'
+
+    def run(self,
+            scenario_state,
+            choices,
+            actions,
+            chosen_choice,
+            chosen_action=None):
+        if chosen_action is None:
+            chosen_choice_idx = choices.index(chosen_choice)
+            chosen_action = actions[chosen_choice_idx]
+
+        # Action requires a character ID
+        if chosen_action.action_type in {'TREAT_PATIENT',
+                                         ActionTypeEnum.MOVE_TO_EVAC,
+                                         ActionTypeEnum.TAG_CHARACTER}:
+            if chosen_action.character_id is None:
+                chosen_action.character_id = random.choice([
+                    c.id
+                    for c in scenario_state.characters
+                    if hasattr(c, "unseen") and not c.unseen
+                ])
+
+        if chosen_action.action_type == ActionTypeEnum.TAG_CHARACTER:
+            if chosen_action.parameters is None:
+                chosen_action.parameters = {}
+
+            if 'category' not in chosen_action.parameters:
+                chosen_action.parameters['category'] = random.choice(
+                    get_swagger_class_enum_values(CharacterTagEnum))
+
         chosen_action.justification = "Random choice"
 
         return chosen_action

--- a/align_system/configs/adm_component/alignment/tournament_random_effects_tuple.yaml
+++ b/align_system/configs/adm_component/alignment/tournament_random_effects_tuple.yaml
@@ -1,0 +1,3 @@
+_target_: align_system.algorithms.alignment_adm_component.TournamentRandomEffectsModelAlignmentADMComponent
+
+attributes: ${ref:adm.attribute_definitions}

--- a/align_system/configs/adm_component/misc/ow_action_parameter_completion.yaml
+++ b/align_system/configs/adm_component/misc/ow_action_parameter_completion.yaml
@@ -1,0 +1,9 @@
+_target_: align_system.algorithms.open_world_components.OWActionParameterCompletionADMComponent
+
+structured_inference_engine: ${ref:adm.structured_inference_engine}
+
+system_prompt:
+  _target_: align_system.prompt_engineering.outlines_prompts.DefaultITMBaselineSystemPrompt
+
+scenario_description_template:
+  _target_: align_system.prompt_engineering.outlines_prompts.Phase2ScenarioDescriptionWCasualtyInfo

--- a/align_system/configs/adm_component/misc/ow_choice_to_action.yaml
+++ b/align_system/configs/adm_component/misc/ow_choice_to_action.yaml
@@ -1,0 +1,14 @@
+_target_: align_system.algorithms.open_world_components.OWChoiceToActionADMComponent
+
+structured_inference_engine: ${ref:adm.structured_inference_engine}
+
+scenario_description_template:
+  _target_: align_system.prompt_engineering.outlines_prompts.Phase2ScenarioDescriptionWCasualtyInfo
+prompt_template:
+  _target_: align_system.prompt_engineering.outlines_prompts.DefaultITMPrompt
+output_schema_template:
+  _target_: align_system.prompt_engineering.outlines_prompts.DefaultChoiceSelectionSchema
+system_prompt_template:
+  _target_: align_system.prompt_engineering.outlines_prompts.DefaultITMBaselineSystemPrompt
+
+num_samples: 1

--- a/align_system/configs/adm_component/misc/ow_format_choices.yaml
+++ b/align_system/configs/adm_component/misc/ow_format_choices.yaml
@@ -1,0 +1,1 @@
+_target_: align_system.algorithms.open_world_components.OWFormatChoicesADMComponent

--- a/align_system/configs/adm_component/misc/ow_random_action_parameter_completion.yaml
+++ b/align_system/configs/adm_component/misc/ow_random_action_parameter_completion.yaml
@@ -1,0 +1,1 @@
+_target_: align_system.algorithms.random_adm_component.OWRandomParameterCompletionADMComponent

--- a/align_system/configs/adm_component/misc/ow_tagging_adjustment.yaml
+++ b/align_system/configs/adm_component/misc/ow_tagging_adjustment.yaml
@@ -1,0 +1,1 @@
+_target_: align_system.algorithms.open_world_components.OWTaggingAdjustmentADMComponent

--- a/align_system/configs/driver/itm_phase2_ow.yaml
+++ b/align_system/configs/driver/itm_phase2_ow.yaml
@@ -1,0 +1,4 @@
+_target_: align_system.drivers.itm_open_world.ITMOpenWorldDriver
+
+apply_action_filtering: true
+sort_available_actions: false

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline.yaml
@@ -16,7 +16,7 @@ adm:
   step_definitions:
     outlines_baseline:
       scenario_description_template:
-        _target_: align_system.prompt_engineering.outlines_prompts.Phase2ScenarioDescription
+        _target_: align_system.prompt_engineering.outlines_prompts.Phase2ScenarioDescriptionWCasualtyInfo
       prompt_template:
         _target_: align_system.prompt_engineering.outlines_prompts.Phase2BaselinePrompt
 

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline.yaml
@@ -33,6 +33,7 @@ adm:
 
 driver:
   expand_actions: true
+  expand_tagging: true
   apply_action_filtering: true
 
 force_determinism: true

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline.yaml
@@ -1,0 +1,39 @@
+# @package _global_
+defaults:
+  - override /adm: pipeline_baseline
+  - override /inference_engine@adm.structured_inference_engine: outlines_structured_greedy
+  - override /interface: ta3
+  - override /driver: itm_phase2_ow
+
+interface:
+  api_endpoint: 'http://127.0.0.1:8081'
+  session_type: eval
+  training_session: null
+  username: "testrun-ALIGN-ADM-OutlinesBaseline-Mistral-7B-Instruct-v0.3"
+  domain: "p2triage"
+
+adm:
+  step_definitions:
+    outlines_baseline:
+      scenario_description_template:
+        _target_: align_system.prompt_engineering.outlines_prompts.Phase2ScenarioDescription
+      prompt_template:
+        _target_: align_system.prompt_engineering.outlines_prompts.Phase2BaselinePrompt
+
+      enable_caching: true
+
+  instance:
+    steps:
+    # Reference the step instances we want to use in order
+    - ${ref:adm.step_definitions.format_choices}
+    - ${ref:adm.step_definitions.outlines_baseline}
+    # - ${ref:adm.step_definitions.action_parameter_completion}
+    - ${ref:adm.step_definitions.ensure_chosen_action}
+    - ${ref:adm.step_definitions.populate_choice_info}
+
+driver:
+  expand_actions: true
+  apply_action_filtering: true
+
+force_determinism: true
+align_to_target: false

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline.yaml
@@ -2,6 +2,7 @@
 defaults:
   - override /adm: pipeline_baseline
   - override /inference_engine@adm.structured_inference_engine: outlines_structured_greedy
+  - override /adm_component/misc@adm.step_definitions.action_parameter_completion: ow_action_parameter_completion
   - override /interface: ta3
   - override /driver: itm_phase2_ow
 
@@ -27,13 +28,13 @@ adm:
     # Reference the step instances we want to use in order
     - ${ref:adm.step_definitions.format_choices}
     - ${ref:adm.step_definitions.outlines_baseline}
-    # - ${ref:adm.step_definitions.action_parameter_completion}
     - ${ref:adm.step_definitions.ensure_chosen_action}
+    - ${ref:adm.step_definitions.action_parameter_completion}
     - ${ref:adm.step_definitions.populate_choice_info}
 
 driver:
   expand_actions: true
-  expand_tagging: true
+  expand_tagging: false
   apply_action_filtering: true
 
 force_determinism: true

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline_live.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline_live.yaml
@@ -1,0 +1,40 @@
+# @package _global_
+defaults:
+  - override /adm: pipeline_baseline
+  - override /inference_engine@adm.structured_inference_engine: outlines_structured_greedy
+  - override /interface: ta3
+  - override /driver: itm_phase2_ow
+
+interface:
+  api_endpoint: "https://darpaitm.caci.com"
+  session_type: eval
+  training_session: null
+  username: "ALIGN-ADM-OutlinesBaseline-Mistral-7B-Instruct-v0.3"
+  domain: "p2triage"
+
+adm:
+  step_definitions:
+    outlines_baseline:
+      scenario_description_template:
+        _target_: align_system.prompt_engineering.outlines_prompts.Phase2ScenarioDescriptionWCasualtyInfo
+      prompt_template:
+        _target_: align_system.prompt_engineering.outlines_prompts.Phase2BaselinePrompt
+
+      enable_caching: true
+
+  instance:
+    steps:
+    # Reference the step instances we want to use in order
+    - ${ref:adm.step_definitions.format_choices}
+    - ${ref:adm.step_definitions.outlines_baseline}
+    # - ${ref:adm.step_definitions.action_parameter_completion}
+    - ${ref:adm.step_definitions.ensure_chosen_action}
+    - ${ref:adm.step_definitions.populate_choice_info}
+
+driver:
+  expand_actions: true
+  expand_tagging: true
+  apply_action_filtering: true
+
+force_determinism: true
+align_to_target: false

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline_live.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline_live.yaml
@@ -2,6 +2,7 @@
 defaults:
   - override /adm: pipeline_baseline
   - override /inference_engine@adm.structured_inference_engine: outlines_structured_greedy
+  - override /adm_component/misc@adm.step_definitions.action_parameter_completion: ow_action_parameter_completion
   - override /interface: ta3
   - override /driver: itm_phase2_ow
 
@@ -27,13 +28,13 @@ adm:
     # Reference the step instances we want to use in order
     - ${ref:adm.step_definitions.format_choices}
     - ${ref:adm.step_definitions.outlines_baseline}
-    # - ${ref:adm.step_definitions.action_parameter_completion}
     - ${ref:adm.step_definitions.ensure_chosen_action}
+    - ${ref:adm.step_definitions.action_parameter_completion}
     - ${ref:adm.step_definitions.populate_choice_info}
 
 driver:
   expand_actions: true
-  expand_tagging: true
+  expand_tagging: false
   apply_action_filtering: true
 
 force_determinism: true

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline_live.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_baseline_live.yaml
@@ -39,3 +39,4 @@ driver:
 
 force_determinism: true
 align_to_target: false
+save_last_unstructured_state_per_scenario: true

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_direct_regression_random_effects.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_direct_regression_random_effects.yaml
@@ -2,44 +2,30 @@
 defaults:
   - /adm_component/misc@adm.step_definitions.action_parameter_completion: ow_action_parameter_completion
   - /adm_component/misc@adm.step_definitions.tagging_adjustment: ow_tagging_adjustment
-  - override /adm: phase2_pipeline_fewshot_comparative_regression_bert_relevance
+  - override /adm: phase2_pipeline_direct_regression
   - override /interface: ta3
   - override /adm_component/misc@adm.step_definitions.format_choices: ow_format_choices
   - override /adm_component/alignment@adm.step_definitions.scalar_alignment: tournament_random_effects_tuple
   - override /adm_component/misc@adm.step_definitions.ensure_chosen_action: ow_choice_to_action
-  - override /template/scenario_description@adm.scenario_description_template: phase2
   - override /driver: itm_phase2_ow
 
 interface:
   api_endpoint: 'http://127.0.0.1:8081'
   session_type: eval
   training_session: null
-  username: "testrun-ALIGN-ADM-Ph2-ComparativeRegression-BertRelevance-Mistral-7B-Instruct-v0.3"
+  username: "testrun-ALIGN-ADM-Ph2-DirectRegression-BertRelevance-Mistral-7B-Instruct-v0.3"
   domain: "p2triage"
 
 adm:
   step_definitions:
-    regression_icl:
-      icl_generator_partial:
-        incontext_settings:
-          number: 20
-          datasets:
-            medical: /data/shared/samba/phase2_icl/Feb2026-MU-train_20251218.json
-            affiliation: /data/shared/samba/phase2_icl/Feb2026-AF-train_20251218.json
-            merit: /data/shared/samba/phase2_icl/Feb2026-MF-train_20251218.json
-            personal_safety: /data/shared/samba/phase2_icl/Feb2026-PS-train_20251218.json
-            search: /data/shared/samba/phase2_icl/Feb2026-SS-train_20251218.json
-      enable_caching: true
-    comparative_regression:
+    direct_regression:
       enable_caching: true
 
   instance:
     steps:
     # Reference the step instances we want to use in order
     - ${ref:adm.step_definitions.format_choices}
-    - ${ref:adm.step_definitions.regression_icl}
-    - ${ref:adm.step_definitions.bert_relevance}
-    - ${ref:adm.step_definitions.comparative_regression}
+    - ${ref:adm.step_definitions.direct_regression}
     #- ${ref:adm.step_definitions.regression_rule_based_correction}
     - ${ref:adm.step_definitions.scalar_alignment}
     - ${ref:adm.step_definitions.justification_from_reasonings}

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_direct_regression_random_effects_live.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_direct_regression_random_effects_live.yaml
@@ -10,10 +10,10 @@ defaults:
   - override /driver: itm_phase2_ow
 
 interface:
-  api_endpoint: 'http://127.0.0.1:8081'
+  api_endpoint: "https://darpaitm.caci.com"
   session_type: eval
   training_session: null
-  username: "testrun-ALIGN-ADM-Ph2-DirectRegression-Mistral-7B-Instruct-v0.3"
+  username: "ALIGN-ADM-Ph2-DirectRegression-Mistral-7B-Instruct-v0.3"
   domain: "p2triage"
 
 adm:

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_direct_regression_random_effects_live.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_direct_regression_random_effects_live.yaml
@@ -43,3 +43,4 @@ driver:
 
 force_determinism: true
 align_to_target: true
+save_last_unstructured_state_per_scenario: true

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_fewshot_comparative_regression_random_effects.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_fewshot_comparative_regression_random_effects.yaml
@@ -21,6 +21,7 @@ adm:
   step_definitions:
     regression_icl:
       icl_generator_partial:
+        _target_: align_system.utils.incontext_utils.Phase2ComparativeRegressionIncontextExampleGeneratorOWConversion
         incontext_settings:
           number: 20
           datasets:

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_fewshot_comparative_regression_random_effects.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_fewshot_comparative_regression_random_effects.yaml
@@ -2,7 +2,7 @@
 defaults:
   - /adm_component/misc@adm.step_definitions.action_parameter_completion: ow_action_parameter_completion
   - /adm_component/misc@adm.step_definitions.tagging_adjustment: ow_tagging_adjustment
-  - override /adm: phase2_pipeline_fewshot_comparative_regression_bert_relevance
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
   - override /interface: ta3
   - override /adm_component/misc@adm.step_definitions.format_choices: ow_format_choices
   - override /adm_component/alignment@adm.step_definitions.scalar_alignment: tournament_random_effects_tuple
@@ -14,7 +14,7 @@ interface:
   api_endpoint: 'http://127.0.0.1:8081'
   session_type: eval
   training_session: null
-  username: "testrun-ALIGN-ADM-Ph2-ComparativeRegression-BertRelevance-Mistral-7B-Instruct-v0.3"
+  username: "testrun-ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3"
   domain: "p2triage"
 
 adm:
@@ -33,13 +33,14 @@ adm:
       enable_caching: true
     comparative_regression:
       enable_caching: true
+    ensure_chosen_action:
+      enable_caching: true
 
   instance:
     steps:
     # Reference the step instances we want to use in order
     - ${ref:adm.step_definitions.format_choices}
     - ${ref:adm.step_definitions.regression_icl}
-    - ${ref:adm.step_definitions.bert_relevance}
     - ${ref:adm.step_definitions.comparative_regression}
     #- ${ref:adm.step_definitions.regression_rule_based_correction}
     - ${ref:adm.step_definitions.scalar_alignment}

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_fewshot_comparative_regression_random_effects.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_fewshot_comparative_regression_random_effects.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+defaults:
+  - override /adm: phase2_pipeline_fewshot_comparative_regression_bert_relevance
+  - override /interface: ta3
+  - override /adm_component/alignment@adm.step_definitions.scalar_alignment: tournament_random_effects_tuple
+  - override /template/scenario_description@adm.scenario_description_template: phase2_w_casualty_info
+  - override /driver: itm_phase2_ow
+
+interface:
+  api_endpoint: 'http://127.0.0.1:8081'
+  session_type: eval
+  training_session: null
+  username: "testrun-ALIGN-ADM-Ph2-ComparativeRegression-BertRelevance-Mistral-7B-Instruct-v0.3"
+  domain: "p2triage"
+
+adm:
+  step_definitions:
+    regression_icl:
+      icl_generator_partial:
+        incontext_settings:
+          number: 20
+          datasets:
+            medical: /data/shared/samba/phase2_icl/Feb2026-MU-train_20251218.json
+            affiliation: /data/shared/samba/phase2_icl/Feb2026-AF-train_20251218.json
+            merit: /data/shared/samba/phase2_icl/Feb2026-MF-train_20251218.json
+            personal_safety: /data/shared/samba/phase2_icl/Feb2026-PS-train_20251218.json
+            search: /data/shared/samba/phase2_icl/Feb2026-SS-train_20251218.json
+      enable_caching: true
+    comparative_regression:
+      enable_caching: true
+
+driver:
+  expand_actions: true
+  apply_action_filtering: true
+
+force_determinism: true
+align_to_target: true

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_fewshot_comparative_regression_random_effects_live.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_fewshot_comparative_regression_random_effects_live.yaml
@@ -57,3 +57,4 @@ driver:
 
 force_determinism: true
 align_to_target: true
+save_last_unstructured_state_per_scenario: true

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_fewshot_comparative_regression_random_effects_live.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_fewshot_comparative_regression_random_effects_live.yaml
@@ -2,23 +2,36 @@
 defaults:
   - /adm_component/misc@adm.step_definitions.action_parameter_completion: ow_action_parameter_completion
   - /adm_component/misc@adm.step_definitions.tagging_adjustment: ow_tagging_adjustment
-  - override /adm: phase2_pipeline_direct_regression
+  - override /adm: phase2_pipeline_fewshot_comparative_regression
   - override /interface: ta3
   - override /adm_component/misc@adm.step_definitions.format_choices: ow_format_choices
   - override /adm_component/alignment@adm.step_definitions.scalar_alignment: tournament_random_effects_tuple
   - override /adm_component/misc@adm.step_definitions.ensure_chosen_action: ow_choice_to_action
+  - override /template/scenario_description@adm.scenario_description_template: phase2
   - override /driver: itm_phase2_ow
 
 interface:
-  api_endpoint: 'http://127.0.0.1:8081'
+  api_endpoint: "https://darpaitm.caci.com"
   session_type: eval
   training_session: null
-  username: "testrun-ALIGN-ADM-Ph2-DirectRegression-Mistral-7B-Instruct-v0.3"
+  username: "ALIGN-ADM-Ph2-ComparativeRegression-Mistral-7B-Instruct-v0.3"
   domain: "p2triage"
 
 adm:
   step_definitions:
-    direct_regression:
+    regression_icl:
+      icl_generator_partial:
+        _target_: align_system.utils.incontext_utils.Phase2ComparativeRegressionIncontextExampleGeneratorOWConversion
+        incontext_settings:
+          number: 20
+          datasets:
+            medical: /data/shared/samba/phase2_icl/Feb2026-MU-train_20251218.json
+            affiliation: /data/shared/samba/phase2_icl/Feb2026-AF-train_20251218.json
+            merit: /data/shared/samba/phase2_icl/Feb2026-MF-train_20251218.json
+            personal_safety: /data/shared/samba/phase2_icl/Feb2026-PS-train_20251218.json
+            search: /data/shared/samba/phase2_icl/Feb2026-SS-train_20251218.json
+      enable_caching: true
+    comparative_regression:
       enable_caching: true
     ensure_chosen_action:
       enable_caching: true
@@ -27,7 +40,8 @@ adm:
     steps:
     # Reference the step instances we want to use in order
     - ${ref:adm.step_definitions.format_choices}
-    - ${ref:adm.step_definitions.direct_regression}
+    - ${ref:adm.step_definitions.regression_icl}
+    - ${ref:adm.step_definitions.comparative_regression}
     #- ${ref:adm.step_definitions.regression_rule_based_correction}
     - ${ref:adm.step_definitions.scalar_alignment}
     - ${ref:adm.step_definitions.justification_from_reasonings}

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_zeroshot_comparative_regression_random_effects.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_zeroshot_comparative_regression_random_effects.yaml
@@ -2,13 +2,14 @@
 defaults:
   - /adm_component/misc@adm.step_definitions.action_parameter_completion: ow_action_parameter_completion
   - /adm_component/misc@adm.step_definitions.tagging_adjustment: ow_tagging_adjustment
-  - override /adm: phase2_pipeline_fewshot_comparative_regression_bert_relevance
+  - override /adm: phase2_pipeline_zeroshot_comparative_regression
   - override /interface: ta3
   - override /adm_component/misc@adm.step_definitions.format_choices: ow_format_choices
   - override /adm_component/alignment@adm.step_definitions.scalar_alignment: tournament_random_effects_tuple
   - override /adm_component/misc@adm.step_definitions.ensure_chosen_action: ow_choice_to_action
   - override /template/scenario_description@adm.scenario_description_template: phase2
   - override /driver: itm_phase2_ow
+
 
 interface:
   api_endpoint: 'http://127.0.0.1:8081'
@@ -19,17 +20,6 @@ interface:
 
 adm:
   step_definitions:
-    regression_icl:
-      icl_generator_partial:
-        incontext_settings:
-          number: 20
-          datasets:
-            medical: /data/shared/samba/phase2_icl/Feb2026-MU-train_20251218.json
-            affiliation: /data/shared/samba/phase2_icl/Feb2026-AF-train_20251218.json
-            merit: /data/shared/samba/phase2_icl/Feb2026-MF-train_20251218.json
-            personal_safety: /data/shared/samba/phase2_icl/Feb2026-PS-train_20251218.json
-            search: /data/shared/samba/phase2_icl/Feb2026-SS-train_20251218.json
-      enable_caching: true
     comparative_regression:
       enable_caching: true
 
@@ -37,8 +27,6 @@ adm:
     steps:
     # Reference the step instances we want to use in order
     - ${ref:adm.step_definitions.format_choices}
-    - ${ref:adm.step_definitions.regression_icl}
-    - ${ref:adm.step_definitions.bert_relevance}
     - ${ref:adm.step_definitions.comparative_regression}
     #- ${ref:adm.step_definitions.regression_rule_based_correction}
     - ${ref:adm.step_definitions.scalar_alignment}

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_zeroshot_comparative_regression_random_effects.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_zeroshot_comparative_regression_random_effects.yaml
@@ -15,12 +15,14 @@ interface:
   api_endpoint: 'http://127.0.0.1:8081'
   session_type: eval
   training_session: null
-  username: "testrun-ALIGN-ADM-Ph2-ComparativeRegression-BertRelevance-Mistral-7B-Instruct-v0.3"
+  username: "testrun-ALIGN-ADM-Ph2-ComparativeRegression-Zeroshot-Mistral-7B-Instruct-v0.3"
   domain: "p2triage"
 
 adm:
   step_definitions:
     comparative_regression:
+      enable_caching: true
+    ensure_chosen_action:
       enable_caching: true
 
   instance:

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_zeroshot_comparative_regression_random_effects_live.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_zeroshot_comparative_regression_random_effects_live.yaml
@@ -2,23 +2,26 @@
 defaults:
   - /adm_component/misc@adm.step_definitions.action_parameter_completion: ow_action_parameter_completion
   - /adm_component/misc@adm.step_definitions.tagging_adjustment: ow_tagging_adjustment
-  - override /adm: phase2_pipeline_direct_regression
+  - override /adm: phase2_pipeline_zeroshot_comparative_regression
   - override /interface: ta3
   - override /adm_component/misc@adm.step_definitions.format_choices: ow_format_choices
   - override /adm_component/alignment@adm.step_definitions.scalar_alignment: tournament_random_effects_tuple
   - override /adm_component/misc@adm.step_definitions.ensure_chosen_action: ow_choice_to_action
+  - override /template/scenario_description@adm.scenario_description_template: phase2
   - override /driver: itm_phase2_ow
 
+
 interface:
-  api_endpoint: 'http://127.0.0.1:8081'
+  api_endpoint: "https://darpaitm.caci.com"
   session_type: eval
   training_session: null
-  username: "testrun-ALIGN-ADM-Ph2-DirectRegression-Mistral-7B-Instruct-v0.3"
+  username: "ALIGN-ADM-Ph2-ComparativeRegression-Zeroshot-Mistral-7B-Instruct-v0.3"
   domain: "p2triage"
 
 adm:
   step_definitions:
-    direct_regression:
+      step_definitions:
+    comparative_regression:
       enable_caching: true
     ensure_chosen_action:
       enable_caching: true
@@ -27,7 +30,7 @@ adm:
     steps:
     # Reference the step instances we want to use in order
     - ${ref:adm.step_definitions.format_choices}
-    - ${ref:adm.step_definitions.direct_regression}
+    - ${ref:adm.step_definitions.comparative_regression}
     #- ${ref:adm.step_definitions.regression_rule_based_correction}
     - ${ref:adm.step_definitions.scalar_alignment}
     - ${ref:adm.step_definitions.justification_from_reasonings}

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_zeroshot_comparative_regression_random_effects_live.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_pipeline_zeroshot_comparative_regression_random_effects_live.yaml
@@ -20,7 +20,6 @@ interface:
 
 adm:
   step_definitions:
-      step_definitions:
     comparative_regression:
       enable_caching: true
     ensure_chosen_action:
@@ -46,3 +45,4 @@ driver:
 
 force_determinism: true
 align_to_target: true
+save_last_unstructured_state_per_scenario: true

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_random.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_random.yaml
@@ -25,6 +25,7 @@ adm:
 
 driver:
   expand_actions: true
+  expand_tagging: true
   apply_action_filtering: true
 
 force_determinism: true

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_random.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_random.yaml
@@ -24,7 +24,8 @@ adm:
     - ${ref:adm.step_definitions.populate_choice_info}
 
 driver:
-  apply_action_filtering: false
+  expand_actions: true
+  apply_action_filtering: true
 
 force_determinism: true
 align_to_target: false

--- a/align_system/configs/experiment/phase2_feb_openworld/phase2_random.yaml
+++ b/align_system/configs/experiment/phase2_feb_openworld/phase2_random.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+defaults:
+  - override /adm: pipeline_random
+  - override /interface: ta3
+  - override /driver: itm_phase2_ow
+  - override /adm_component/misc@adm.step_definitions.random_action_parameter_completion: ow_random_action_parameter_completion
+
+interface:
+  api_endpoint: 'http://127.0.0.1:8081'
+  session_type: eval
+  training_session: null
+  username: "testrun-pipeline_random"
+  domain: "p2triage"
+
+adm:
+  instance:
+    steps:
+    # Reference the step instances we want to use in order
+    - ${ref:adm.step_definitions.format_choices}
+    - ${ref:adm.step_definitions.random_choice}
+    - ${ref:adm.step_definitions.random_action_parameter_completion}
+    # - ${ref:adm.step_definitions.action_parameter_completion}
+    - ${ref:adm.step_definitions.ensure_chosen_action}
+    - ${ref:adm.step_definitions.populate_choice_info}
+
+driver:
+  apply_action_filtering: false
+
+force_determinism: true
+align_to_target: false

--- a/align_system/configs/template/scenario_description/phase2_w_casualty_info.yaml
+++ b/align_system/configs/template/scenario_description/phase2_w_casualty_info.yaml
@@ -1,0 +1,1 @@
+_target_: align_system.prompt_engineering.outlines_prompts.Phase2ScenarioDescriptionWCasualtyInfo

--- a/align_system/drivers/itm_open_world.py
+++ b/align_system/drivers/itm_open_world.py
@@ -1,0 +1,386 @@
+import os
+import json
+import random
+import re
+from copy import deepcopy
+
+from rich.highlighter import JSONHighlighter
+import hydra
+from omegaconf import DictConfig, OmegaConf
+from swagger_client.models import ActionTypeEnum
+from timeit import default_timer as timer
+
+from align_system.utils import logging
+from align_system.utils.version import get_version
+from align_system.exceptions import SceneSkipException
+
+log = logging.getLogger(__name__)
+JSON_HIGHLIGHTER = JSONHighlighter()
+
+
+class ITMOpenWorldDriver:
+    def __init__(self,
+                apply_action_filtering=True,
+                sort_available_actions=False):
+        self.apply_action_filtering = apply_action_filtering
+        self.sort_available_actions = sort_available_actions
+
+    def _expand_action_by_character(self, action, characters, restricted_character_ids):
+        expanded_actions = []
+
+        for character in characters:
+            if character.id in restricted_character_ids:
+                continue
+
+            new_action = deepcopy(action)
+            new_action.character_id = character.id
+            new_action.unstructured = re.sub(r"(a )?Patient", character.name, action.unstructured)
+
+            expanded_actions.append(new_action)
+
+        return expanded_actions
+
+
+    def drive(self, cfg):
+        interface = cfg.interface
+        adm = cfg.adm.instance
+
+        # Using the hydra generated output directory for the run
+        output_dir = hydra.core.hydra_config.HydraConfig.get().runtime.output_dir
+
+        save_input_output_to_path = None
+        if cfg.save_input_output:
+            save_input_output_to_path = os.path.join(output_dir, "input_output.json")
+
+        save_alignment_score_to_path = None
+        if cfg.save_scoring_output:
+            save_alignment_score_to_path = os.path.join(output_dir, "scores.json")
+
+        save_alignment_targets_to_path = None
+        if cfg.save_alignment_targets:
+            save_alignment_targets_to_path = os.path.join(output_dir, "targets")
+            os.mkdir(save_alignment_targets_to_path)
+
+        save_timing_to_path = None
+        if cfg.save_timing:
+            save_timing_to_path = os.path.join(output_dir, "timing.json")
+
+        if cfg.get('force_determinism', False) or self.sort_available_actions:
+            log.info("Setting `sort_available_actions` to True")
+            sort_available_actions = True
+        else:
+            sort_available_actions = False
+
+        # HACK: need to invoke 'load_model' for ADMs that require it,
+        # maybe it makes more sense to load_model in the init method for
+        # those ADMs
+        if hasattr(adm, 'load_model'):
+            adm.load_model()
+
+        # Capture inputs and outputs in a similar format to what's used by
+        # our internal evaluation framework code
+        inputs_outputs = []
+
+        # Write version sidecar once at the start of the run
+        meta = {"version": get_version()}
+        username = getattr(interface, 'username', None)
+        if username is not None:
+            meta["username"] = username
+        with open(os.path.join(output_dir, "meta.json"), 'w') as f:
+            json.dump(meta, f, indent=2)
+
+        session_alignment_scores = []
+
+        # Capture time it takes to choose each action
+        action_times = { "scenarios": [] }
+        def _compute_time_stats(times_s):
+            n_times = len(times_s)
+            total_time_s = sum(times_s)
+            return {
+                "n_actions_taken": n_times,
+                "total_time_s": total_time_s,
+                "avg_time_s": total_time_s / n_times if n_times else 0.,
+                "max_time_s": max(times_s) if n_times else 0.,
+                "raw_times_s": times_s
+            }
+
+        # Loop through available scenarios
+        while scenario := interface.start_scenario():
+            if scenario.id() == '':
+                log.info("Next scenario ID is blank, assuming we're done, exiting")
+                break
+            log.info(f'[bold]*Scenario ID*[/bold]: {scenario.id()}')
+
+            # Reset any decision or chat history for a new scenario
+            if hasattr(adm, 'reset_history'):
+                log.info("[bold]*Resetting choice history*[/bold]")
+                adm.reset_history()
+
+            if 'alignment_target' in cfg:
+                alignment_target = cfg.alignment_target
+                # Alignment targets specified in hydra configs require
+                # some nested conversion to dict (from OmegaConf objects)
+                # otherwise this can cause some downstream issues with
+                # serialization
+                alignment_target.kdma_values = [OmegaConf.to_container(c)
+                                                if isinstance(c, DictConfig) else c
+                                                for c in alignment_target.kdma_values]
+            elif cfg.align_to_target:
+                alignment_target = scenario.get_alignment_target()
+            else:
+                alignment_target = None
+
+            log.info('[bold]*ALIGNMENT TARGET*[/bold]')
+            if alignment_target is None:
+                log.info('Alignment target is `None`')
+            else:
+                log.info(alignment_target)
+                if save_alignment_targets_to_path is not None:
+                    alignment_target_path = os.path.join(save_alignment_targets_to_path, f"{alignment_target.id}.json")
+
+                    with open(alignment_target_path, "w") as f:
+                        json.dump(alignment_target.to_dict(), f, indent=2)
+
+            current_state = scenario.get_state()
+            scenario_complete = current_state.scenario_complete
+
+            sce_times_s = []
+
+            last_scene_id = None
+
+            treated_patients = []
+            evac_patients = []
+
+            while not scenario_complete:
+                current_scene_id = current_state.meta_info.scene_id
+                if last_scene_id != current_scene_id:
+                    log.info(f"[bold]*CHANGED SCENE TO*: {current_scene_id}[/bold]",
+                             extra={"markup": True})
+                    last_scene_id = current_scene_id
+
+                available_actions = scenario.get_available_actions()
+
+                if sort_available_actions:
+                    # Impose a fixed ordering of available actions to help
+                    # with determinism
+                    available_actions = sorted(available_actions, key=lambda a: a.unstructured)
+
+                log.debug("[bold]*AVAILABLE ACTIONS*[/bold]",
+                          extra={"markup": True})
+                log.debug(json.dumps([a.to_dict() if hasattr(a, "to_dict") else a._asdict() for a in available_actions], indent=4),
+                          extra={"highlighter": JSON_HIGHLIGHTER})
+
+                if not self.apply_action_filtering:
+                    available_actions_filtered = available_actions
+                else:
+                    available_actions_filtered = []
+                    end_scene_idx = None
+                    for idx, a in enumerate(available_actions):
+                        if a.action_type == ActionTypeEnum.END_SCENE:
+                            # We want to restrict end scene until all characters have been treated
+                            end_scene_idx = idx
+                            continue
+
+                        if a.action_type == ActionTypeEnum.TAG_CHARACTER:
+                            # Don't let ADM choose to tag a character unless there are
+                            # still untagged characters
+                            untagged_characters = [c for c in current_state.characters
+                                                if c.tag is None and not c.unseen]
+
+                            available_actions_filtered.extend(self._expand_action_by_character(
+                                action=a,
+                                characters=untagged_characters,
+                                restricted_character_ids=[],
+                            ))
+
+                        if a.action_type == ActionTypeEnum.TREAT_PATIENT:
+                            treatable_patients = [c for c in current_state.characters if not c.unseen]
+
+                            available_actions_filtered.extend(self._expand_action_by_character(
+                                action=a,
+                                characters=treatable_patients,
+                                restricted_character_ids=treated_patients,
+                            ))
+
+
+                        if a.action_type == ActionTypeEnum.MOVE_TO_EVAC:
+                            evacable_patients = [c for c in current_state.characters if not c.unseen]
+
+                            available_actions_filtered.extend(self._expand_action_by_character(
+                                action=a,
+                                characters=evacable_patients,
+                                restricted_character_ids=evac_patients,
+                            ))
+
+                if len(available_actions_filtered) == 0:
+                    if end_scene_idx is not None:  # All patients have been tagged and treated
+                        log.info("** All patients have been tagged and treated, ending scene")
+                        action_to_take = available_actions[end_scene_idx]
+                        action_to_take.justification = "All patients have been tagged and treated"
+                    else:
+                        raise RuntimeError("No available actions from filtered list!")
+                elif len(available_actions_filtered) == 1:
+                    log.info("** Choosing only available (filtered) action")
+                    action_to_take = available_actions_filtered[0]
+                    action_to_take.justification = "Only available (filtered) action"
+                else:
+                    start_choose_action = timer()
+
+                    try:
+                        # Passing in a copy of available actions to
+                        # prevent ADMs from modifying the originals (should
+                        # considering doing the same for current_state and
+                        # alignment_target)
+                        choose_action_result = adm.choose_action(
+                            current_state,
+                            [deepcopy(a) for a in available_actions_filtered],
+                            alignment_target if cfg.align_to_target else None,
+                            scenario_id=scenario.id(),
+                            **cfg.adm.get('inference_kwargs', {}))
+
+                        # Handle choose action result (for backwards compatibility if no choice_info)
+                        if isinstance(choose_action_result, tuple):
+                            action_to_take, choice_info = choose_action_result
+                            if 'choice_info' in choice_info:
+                                # Handle pipeline_adm
+                                choice_info = choice_info['choice_info']
+                        else:
+                            action_to_take = choose_action_result
+                            choice_info = {}
+
+                    except SceneSkipException as e:
+                        log.error(f"Scene skipped due to component failure: {e}")
+                        log.info(f"Component {e.component_name} failed - choosing random action to advance scene")
+
+                        # Choose a random action from available_actions_filtered to advance the scenario
+                        action_to_take = random.choice(available_actions_filtered)
+                        action_to_take.justification = f"Random action chosen due to component failure: {e.component_name}"
+                        choice_info = {}
+
+                        log.warning(f"Taking random action to advance: {action_to_take.action_type if hasattr(action_to_take, 'action_type') else 'unknown'}")
+
+                    # Common code for both success and exception paths
+                    end_choose_action = timer()
+                    sce_times_s.append(end_choose_action - start_choose_action)
+                    log.debug(f"choose_action took {end_choose_action - start_choose_action} seconds")
+
+                log.info("[bold]*ACTION BEING TAKEN*[/bold]",
+                        extra={"markup": True})
+                if isinstance(action_to_take, dict):
+                    log.info(json.dumps(action_to_take, indent=4),
+                             extra={"highlighter": JSON_HIGHLIGHTER})
+                else:
+                    log.info(json.dumps(action_to_take.to_dict() if hasattr(action_to_take, "to_dict") else action_to_take._asdict(), indent=4),
+                             extra={"highlighter": JSON_HIGHLIGHTER})
+
+                action_choice_idx = None
+                for i, a in enumerate(available_actions):
+                    if a.action_id == action_to_take.action_id:
+                        action_choice_idx = i
+                        break
+
+                # Ensure that 'actions' stored in 'choice_info' are serializable
+                for info in choice_info.values():
+                    if 'action' in info:
+                        info['action'] = info['action'].to_dict()
+
+                inputs_outputs.append({'input': {'scenario_id': scenario.id(),
+                                                 'alignment_target_id': alignment_target.id if cfg.align_to_target else None,
+                                                 'full_state': current_state.to_dict() if hasattr(current_state, "to_dict") else current_state._asdict(),
+                                                 'state': current_state.unstructured,
+                                                 'choices': [a.to_dict() if hasattr(a, "to_dict") else a._asdict() for a in available_actions]},
+                                       'label': [{} if a.kdma_association is None else a.kdma_association for a in available_actions],
+                                       'choice_info': choice_info,
+                                       'output': {'choice': action_choice_idx,
+                                                  'action': action_to_take.to_dict() if hasattr(action_to_take, "to_dict") else action_to_take._asdict()}})
+                # Save input_output after each action (gets overwritten
+                # each time) so that we don't lose everything if the run
+                # crashes or is interrupted.  Could treat this as we do
+                # the logfile and open the file handle once and close
+                # `atexit` and write each line as it's generated (and make
+                # it a .jsonl file; would need to remove the indent=2)
+                if save_input_output_to_path is not None:
+                    with open(save_input_output_to_path, 'w') as f:
+                        json.dump(inputs_outputs, f, indent=2)
+
+                try:
+                    if hasattr(action_to_take, "intent_action") and action_to_take.intent_action:
+                        current_state = scenario.intend_action(action_to_take)
+                    else:
+                        current_state = scenario.take_action(action_to_take)
+                except Exception as e:
+                    log.info(action_to_take)
+                    raise e
+
+                # If we treated a patient, record that treatment so we can ensure we treat everyone
+                if action_to_take.action_type == ActionTypeEnum.TREAT_PATIENT:
+                    treated_patients.append(action_to_take.character_id)
+                # If we evaced a patient, record that so we don't try to evac them again
+                if action_to_take.action_type == ActionTypeEnum.MOVE_TO_EVAC:
+                    evac_patients.append(action_to_take.character_id)
+
+                scenario_complete = current_state.scenario_complete
+
+                if scenario_complete:
+                    log.info("*Final state unstructured*: {}".format(
+                        current_state.unstructured))
+
+                    if cfg.get('save_last_unstructured_state_per_scenario', False):
+                        if alignment_target is None:
+                            scenario_alignment_target = scenario.get_alignment_target()
+
+                            if scenario_alignment_target is not None:
+                                alignment_target_id = scenario_alignment_target.id
+                            else:
+                                alignment_target_id = None
+                        else:
+                            alignment_target_id = alignment_target.id
+
+                        final_scenario_state_output_path = os.path.join(
+                            output_dir, "{}.{}.final_state_unstructured.json".format(
+                                scenario.id(), alignment_target_id))
+                        with open(final_scenario_state_output_path, "w") as f:
+                            print(current_state.unstructured, file=f)
+
+            if save_timing_to_path is not None:
+                action_times["scenarios"].append(_compute_time_stats(sce_times_s))
+
+            if alignment_target is not None:
+                try:
+                    session_alignment = interface.get_session_alignment(
+                        alignment_target)
+                except Exception:
+                    # Could be more specific about what kind of exceptions
+                    # to expect here
+                    session_alignment = None
+
+                if session_alignment is None:
+                    log.info("Couldn't get session alignment from interface")
+                else:
+                    session_alignment_scores.append(session_alignment)
+
+                    if isinstance(session_alignment, dict):
+                        session_alignment_dict = session_alignment
+                    else:
+                        session_alignment_dict = session_alignment.to_dict()
+
+                    log.info("[bold]*TA1 Alignment Score*[/bold]",
+                             extra={"markup": True})
+                    log.info(json.dumps(session_alignment_dict, indent=4),
+                             extra={"highlighter": JSON_HIGHLIGHTER})
+
+        if save_timing_to_path is not None:
+            all_times = []
+            for sce in action_times["scenarios"]:
+                all_times.extend(sce["raw_times_s"])
+
+            action_times.update(_compute_time_stats(all_times))
+
+            with open(save_timing_to_path, 'w') as f:
+                json.dump(action_times, f, indent=2)
+
+        if len(session_alignment_scores) > 0:
+            if save_alignment_score_to_path is not None:
+                with open(save_alignment_score_to_path, 'w') as f:
+                    json.dump([(s if isinstance(s, dict) else s.to_dict())
+                               for s in session_alignment_scores], f, indent=2)

--- a/align_system/drivers/itm_open_world.py
+++ b/align_system/drivers/itm_open_world.py
@@ -10,31 +10,57 @@ from omegaconf import DictConfig, OmegaConf
 from swagger_client.models import ActionTypeEnum
 from timeit import default_timer as timer
 
+from align_system.utils import get_swagger_class_enum_values
 from align_system.utils import logging
 from align_system.utils.version import get_version
 from align_system.exceptions import SceneSkipException
+from align_system.data_models.compat.ta3_ph1_client_models import (
+    CharacterTagEnum)
+
 
 log = logging.getLogger(__name__)
 JSON_HIGHLIGHTER = JSONHighlighter()
 
+DEFAULT_TAGS = get_swagger_class_enum_values(CharacterTagEnum)
 
 class ITMOpenWorldDriver:
     def __init__(self,
                 apply_action_filtering=True,
+                expand_actions=False,
                 sort_available_actions=False):
         self.apply_action_filtering = apply_action_filtering
+        self.expand_actions = expand_actions
         self.sort_available_actions = sort_available_actions
 
-    def _expand_action_by_character(self, action, characters, restricted_character_ids):
+    def _expand_action_by_character(self, action, characters):
         expanded_actions = []
 
         for character in characters:
-            if character.id in restricted_character_ids:
-                continue
-
             new_action = deepcopy(action)
             new_action.character_id = character.id
             new_action.unstructured = re.sub(r"(a )?Patient", character.name, action.unstructured)
+
+            expanded_actions.append(new_action)
+
+        return expanded_actions
+
+    def _expand_action_by_tag(self, action, possible_tags=DEFAULT_TAGS):
+        assert action.action_type == ActionTypeEnum.TAG_CHARACTER
+
+        expanded_actions = []
+
+        for tag in possible_tags:
+            new_action = deepcopy(action)
+            if new_action.parameters is None:
+                new_action.parameters = {}
+
+            new_action.parameters['category'] = tag
+            if re.match(r'^[aeiou]', tag, re.I):
+                prefix = "an"
+            else:
+                prefix = "a"
+
+            new_action.unstructured = re.sub(r"a triage tag", f"{prefix} {tag} triage tag", action.unstructured)
 
             expanded_actions.append(new_action)
 
@@ -148,8 +174,8 @@ class ITMOpenWorldDriver:
 
             last_scene_id = None
 
-            treated_patients = []
-            evac_patients = []
+            treated_patients = set()
+            evac_patients = set()
 
             while not scenario_complete:
                 current_scene_id = current_state.meta_info.scene_id
@@ -170,47 +196,80 @@ class ITMOpenWorldDriver:
                 log.debug(json.dumps([a.to_dict() if hasattr(a, "to_dict") else a._asdict() for a in available_actions], indent=4),
                           extra={"highlighter": JSON_HIGHLIGHTER})
 
+                if not self.expand_actions:
+                    available_actions_expanded = available_actions
+                if self.expand_actions:
+                    available_actions_expanded = []
+                    for idx, a in enumerate(available_actions):
+                        if a.action_type == ActionTypeEnum.TAG_CHARACTER:
+                            # Expanding twice here, once for
+                            # characters, and again for possible tags
+                            for char_expanded_action in self._expand_action_by_character(
+                                    action=a,
+                                    characters=current_state.characters):
+                                available_actions_expanded.extend(self._expand_action_by_tag(
+                                    action=char_expanded_action))
+
+                        elif a.action_type == ActionTypeEnum.TREAT_PATIENT:
+                            available_actions_expanded.extend(self._expand_action_by_character(
+                                action=a,
+                                characters=current_state.characters
+                            ))
+
+
+                        elif a.action_type == ActionTypeEnum.MOVE_TO_EVAC:
+                            available_actions_expanded.extend(self._expand_action_by_character(
+                                action=a,
+                                characters=current_state.characters
+                            ))
+
+                        else:
+                            available_actions_expanded.append(a)
+
+                    log.debug("[bold]*AVAILABLE ACTIONS EXPANDED*[/bold]",
+                              extra={"markup": True})
+                    log.debug(json.dumps([a.to_dict() if hasattr(a, "to_dict") else a._asdict() for a in available_actions_expanded], indent=4),
+                              extra={"highlighter": JSON_HIGHLIGHTER})
+
+
                 if not self.apply_action_filtering:
-                    available_actions_filtered = available_actions
+                    available_actions_filtered = available_actions_expanded
                 else:
                     available_actions_filtered = []
                     end_scene_idx = None
-                    for idx, a in enumerate(available_actions):
+
+                    untagged_characters = {c.id for c in current_state.characters
+                                           if c.tag is None and not c.unseen}
+                    # HACK: Current TA3 server doesn't track what
+                    # patients have been treated or evac'd (via
+                    # c.unseen, or any other means); need to track it
+                    # manually
+                    # treatable_patients = {c.id for c in current_state.characters if not c.unseen}
+                    # evacable_patients = {c.id for c in current_state.characters if not c.unseen}
+                    treatable_patients = {c.id for c in current_state.characters if c.id not in treated_patients}
+                    evacable_patients = {c.id for c in current_state.characters if c.id not in evac_patients}
+
+                    for idx, a in enumerate(available_actions_expanded):
                         if a.action_type == ActionTypeEnum.END_SCENE:
                             # We want to restrict end scene until all characters have been treated
                             end_scene_idx = idx
                             continue
 
-                        if a.action_type == ActionTypeEnum.TAG_CHARACTER:
+                        elif a.action_type == ActionTypeEnum.TAG_CHARACTER:
                             # Don't let ADM choose to tag a character unless there are
                             # still untagged characters
-                            untagged_characters = [c for c in current_state.characters
-                                                if c.tag is None and not c.unseen]
+                            if a.character_id not in untagged_characters:
+                                continue
 
-                            available_actions_filtered.extend(self._expand_action_by_character(
-                                action=a,
-                                characters=untagged_characters,
-                                restricted_character_ids=[],
-                            ))
+                        elif a.action_type == ActionTypeEnum.TREAT_PATIENT:
+                            if a.character_id not in treatable_patients:
+                                continue
 
-                        if a.action_type == ActionTypeEnum.TREAT_PATIENT:
-                            treatable_patients = [c for c in current_state.characters if not c.unseen]
+                        elif a.action_type == ActionTypeEnum.MOVE_TO_EVAC:
+                            if a.character_id not in evacable_patients:
+                                continue
 
-                            available_actions_filtered.extend(self._expand_action_by_character(
-                                action=a,
-                                characters=treatable_patients,
-                                restricted_character_ids=treated_patients,
-                            ))
-
-
-                        if a.action_type == ActionTypeEnum.MOVE_TO_EVAC:
-                            evacable_patients = [c for c in current_state.characters if not c.unseen]
-
-                            available_actions_filtered.extend(self._expand_action_by_character(
-                                action=a,
-                                characters=evacable_patients,
-                                restricted_character_ids=evac_patients,
-                            ))
+                        available_actions_filtered.append(a)
 
                 if len(available_actions_filtered) == 0:
                     if end_scene_idx is not None:  # All patients have been tagged and treated
@@ -219,10 +278,6 @@ class ITMOpenWorldDriver:
                         action_to_take.justification = "All patients have been tagged and treated"
                     else:
                         raise RuntimeError("No available actions from filtered list!")
-                elif len(available_actions_filtered) == 1:
-                    log.info("** Choosing only available (filtered) action")
-                    action_to_take = available_actions_filtered[0]
-                    action_to_take.justification = "Only available (filtered) action"
                 else:
                     start_choose_action = timer()
 
@@ -314,10 +369,10 @@ class ITMOpenWorldDriver:
 
                 # If we treated a patient, record that treatment so we can ensure we treat everyone
                 if action_to_take.action_type == ActionTypeEnum.TREAT_PATIENT:
-                    treated_patients.append(action_to_take.character_id)
+                    treated_patients.add(action_to_take.character_id)
                 # If we evaced a patient, record that so we don't try to evac them again
                 if action_to_take.action_type == ActionTypeEnum.MOVE_TO_EVAC:
-                    evac_patients.append(action_to_take.character_id)
+                    evac_patients.add(action_to_take.character_id)
 
                 scenario_complete = current_state.scenario_complete
 

--- a/align_system/drivers/itm_open_world.py
+++ b/align_system/drivers/itm_open_world.py
@@ -27,9 +27,11 @@ class ITMOpenWorldDriver:
     def __init__(self,
                 apply_action_filtering=True,
                 expand_actions=False,
+                expand_tagging=False,
                 sort_available_actions=False):
         self.apply_action_filtering = apply_action_filtering
         self.expand_actions = expand_actions
+        self.expand_tagging = expand_tagging
         self.sort_available_actions = sort_available_actions
 
     def _expand_action_by_character(self, action, characters):
@@ -65,7 +67,6 @@ class ITMOpenWorldDriver:
             expanded_actions.append(new_action)
 
         return expanded_actions
-
 
     def drive(self, cfg):
         interface = cfg.interface
@@ -202,13 +203,18 @@ class ITMOpenWorldDriver:
                     available_actions_expanded = []
                     for idx, a in enumerate(available_actions):
                         if a.action_type == ActionTypeEnum.TAG_CHARACTER:
-                            # Expanding twice here, once for
-                            # characters, and again for possible tags
-                            for char_expanded_action in self._expand_action_by_character(
+                            tagging_by_character = self._expand_action_by_character(
                                     action=a,
-                                    characters=current_state.characters):
-                                available_actions_expanded.extend(self._expand_action_by_tag(
-                                    action=char_expanded_action))
+                                    characters=current_state.characters
+                            )
+                            if self.expand_tagging:
+                                # Expanding twice here, once for
+                                # characters, and again for possible tags
+                                for char_expanded_action in tagging_by_character:
+                                    available_actions_expanded.extend(self._expand_action_by_tag(
+                                        action=char_expanded_action))
+                            else:
+                                available_actions_expanded.extend(tagging_by_character)
 
                         elif a.action_type == ActionTypeEnum.TREAT_PATIENT:
                             available_actions_expanded.extend(self._expand_action_by_character(
@@ -231,48 +237,64 @@ class ITMOpenWorldDriver:
                     log.debug(json.dumps([a.to_dict() if hasattr(a, "to_dict") else a._asdict() for a in available_actions_expanded], indent=4),
                               extra={"highlighter": JSON_HIGHLIGHTER})
 
-
                 if not self.apply_action_filtering:
                     available_actions_filtered = available_actions_expanded
                 else:
                     available_actions_filtered = []
-                    end_scene_idx = None
-
-                    untagged_characters = {c.id for c in current_state.characters
-                                           if c.tag is None and not c.unseen}
-                    # HACK: Current TA3 server doesn't track what
-                    # patients have been treated or evac'd (via
-                    # c.unseen, or any other means); need to track it
-                    # manually
-                    # treatable_patients = {c.id for c in current_state.characters if not c.unseen}
-                    # evacable_patients = {c.id for c in current_state.characters if not c.unseen}
-                    treatable_patients = {c.id for c in current_state.characters if c.id not in treated_patients}
-                    evacable_patients = {c.id for c in current_state.characters if c.id not in evac_patients}
-
-                    for idx, a in enumerate(available_actions_expanded):
+                    for a in available_actions_expanded:
                         if a.action_type == ActionTypeEnum.END_SCENE:
                             # We want to restrict end scene until all characters have been treated
-                            end_scene_idx = idx
                             continue
 
                         elif a.action_type == ActionTypeEnum.TAG_CHARACTER:
-                            # Don't let ADM choose to tag a character unless there are
-                            # still untagged characters
-                            if a.character_id not in untagged_characters:
+                            untagged_characters = {
+                                c.id for c in current_state.characters
+                                if c.tag is None and not c.unseen
+                            }
+                            if len(untagged_characters) == 0:  # No more patients to tag
+                                continue
+                            if a.character_id is not None and a.character_id not in untagged_characters:
                                 continue
 
+                        # HACK: Current TA3 server doesn't track what patients have been
+                        # treated or evac'd (via c.unseen, or any other means); need to
+                        # track it manually
                         elif a.action_type == ActionTypeEnum.TREAT_PATIENT:
-                            if a.character_id not in treatable_patients:
+                            treatable_patients = {
+                                c.id for c in current_state.characters
+                                if c.id not in treated_patients
+                            }
+                            if len(treatable_patients) == 0:  # No more patients to treat
+                                continue
+                            if a.character_id is not None and a.character_id not in treatable_patients:
                                 continue
 
                         elif a.action_type == ActionTypeEnum.MOVE_TO_EVAC:
-                            if a.character_id not in evacable_patients:
+                            evacable_patients = {
+                                c.id for c in current_state.characters
+                                if c.id not in evac_patients
+                            }
+                            if len(evacable_patients) == 0:  # No more patients to evac
+                                continue
+                            if a.character_id is not None and a.character_id not in evacable_patients:
                                 continue
 
                         available_actions_filtered.append(a)
 
+                    log.debug("[bold]*AVAILABLE ACTIONS FILTERED*[/bold]",
+                              extra={"markup": True})
+                    log.debug(json.dumps([a.to_dict() if hasattr(a, "to_dict") else a._asdict() for a in available_actions_filtered], indent=4),
+                              extra={"highlighter": JSON_HIGHLIGHTER})
+
                 if len(available_actions_filtered) == 0:
-                    if end_scene_idx is not None:  # All patients have been tagged and treated
+                    end_scene_idx = None
+                    # Expanded actions because END_SCENE is explicitly excluded from the filtered actions
+                    for idx, a in enumerate(available_actions_expanded):
+                        if a.action_type == ActionTypeEnum.END_SCENE:
+                            end_scene_idx = idx
+                            break
+
+                    if end_scene_idx is not None:
                         log.info("** All patients have been tagged and treated, ending scene")
                         action_to_take = available_actions[end_scene_idx]
                         action_to_take.justification = "All patients have been tagged and treated"
@@ -348,6 +370,7 @@ class ITMOpenWorldDriver:
                                        'choice_info': choice_info,
                                        'output': {'choice': action_choice_idx,
                                                   'action': action_to_take.to_dict() if hasattr(action_to_take, "to_dict") else action_to_take._asdict()}})
+
                 # Save input_output after each action (gets overwritten
                 # each time) so that we don't lose everything if the run
                 # crashes or is interrupted.  Could treat this as we do

--- a/align_system/interfaces/ta3_caci_action_based_service.py
+++ b/align_system/interfaces/ta3_caci_action_based_service.py
@@ -121,9 +121,10 @@ class TA3CACIActionBasedScenario(ActionBasedScenarioInterface):
                 session_id=self.session_id,
                 action=action)
 
-            updated_state.unstructured = "{}\n{}".format(
-                updated_state.threat_state.unstructured,
-                updated_state.unstructured)
+            if updated_state.threat_state is not None:
+                updated_state.unstructured = "{}\n{}".format(
+                    updated_state.threat_state.unstructured,
+                    updated_state.unstructured)
         else:
             updated_state = take_or_intend(
                 session_id=self.session_id,
@@ -146,8 +147,9 @@ class TA3CACIActionBasedScenario(ActionBasedScenarioInterface):
             session_id=self.session_id, scenario_id=self.scenario.id)
 
         if self.domain == "p2triage":
-            state.unstructured = "{}\n{}".format(
-                state.threat_state.unstructured,
-                state.unstructured)
+            if state.threat_state is not None:
+                state.unstructured = "{}\n{}".format(
+                    state.threat_state.unstructured,
+                    state.unstructured)
 
         return state

--- a/align_system/prompt_engineering/outlines_prompts.py
+++ b/align_system/prompt_engineering/outlines_prompts.py
@@ -1216,6 +1216,22 @@ class Phase2ScenarioDescription():
 
 
 @compat_outlines_prompt
+def phase2_scenario_state_description_w_casualty_info(scenario_state):
+    """
+    {{ scenario_state.unstructured.rstrip() }}
+
+    Casualties:
+    {% for c in scenario_state.characters %}
+    - {{ c.name }}: {{ c.unstructured }}
+    {% endfor %}
+    """
+
+class Phase2ScenarioDescriptionWCasualtyInfo():
+    def __call__(self, scenario_state):
+        return phase2_scenario_state_description_w_casualty_info(scenario_state)
+
+
+@compat_outlines_prompt
 def phase2_baseline_prompt(scenario_description, choices):
     """
     Scenario:

--- a/align_system/prompt_engineering/ow_prompts.py
+++ b/align_system/prompt_engineering/ow_prompts.py
@@ -1,0 +1,37 @@
+import jinja2
+import json
+import re
+
+from align_system.prompt_engineering.compat.outlines.templates import prompt as compat_outlines_prompt
+
+
+@compat_outlines_prompt
+def followup_clarify_tag(character):
+    """
+    Given the casualty description below, please state what triage tag \
+    should be applied to the casualty given their injuries and vitals
+
+    {{ character.unstructured }}
+    """
+
+class FollowupClarifyTagPrompt:
+    def __call__(self, character):
+        return followup_clarify_tag(character)
+
+
+@compat_outlines_prompt
+def followup_clarify_character(scenario_description, action):
+    """
+    Given the scenario description and selected action, please clarify which \
+    character should receive the action.
+
+    SCENARIO DESCRIPTION:
+    {{ scenario_descriptoin }}
+
+    SELECTED ACTION:
+    {{ action.unstructured }}
+    """
+
+class FollowupClarifyCharacterPrompt:
+    def __call__(self, scenario_description, action):
+        return followup_clarify_character(scenario_description, action)

--- a/align_system/prompt_engineering/ow_prompts.py
+++ b/align_system/prompt_engineering/ow_prompts.py
@@ -8,9 +8,19 @@ from align_system.prompt_engineering.compat.outlines.templates import prompt as 
 @compat_outlines_prompt
 def followup_clarify_tag(character):
     """
-    Given the casualty description below, please state what triage tag \
-    should be applied to the casualty given their injuries and vitals
+    Given the description below, please state what triage category \
+    should be applied to the patient given their injuries and vitals. \
+    When selecting a triage category, consider the following criteria:
+    - IMMEDIATE: Life-threatening injuries requiring immediate intervention \
+    and likely to survive if treated promptly.
+    - DELAYED: Serious injuries requiring medical care but treatment can \
+    safely be delayed.
+    - MINOR: Walking wounded or patients with minor injuries who can safely \
+    wait.
+    - EXPECTANT: Injuries so severe that survival is unlikely given available \
+    resources during the incident. This category should be used sparingly.
 
+    Description:
     {{ character.unstructured }}
     """
 
@@ -25,10 +35,10 @@ def followup_clarify_character(scenario_description, action):
     Given the scenario description and selected action, please clarify which \
     character should receive the action.
 
-    SCENARIO DESCRIPTION:
+    Scenario:
     {{ scenario_descriptoin }}
 
-    SELECTED ACTION:
+    Selected action:
     {{ action.unstructured }}
     """
 

--- a/align_system/tests/test_alignment_adm_component.py
+++ b/align_system/tests/test_alignment_adm_component.py
@@ -7,7 +7,9 @@ from align_system.algorithms.alignment_adm_component import (
     MedicalUrgencyAlignmentADMComponent,
     MedicalUrgencyAlignmentWeightedADMComponent,
     RandomEffectsModelAlignmentADMComponent,
-    MultinomialRandomEffectsModelAlignmentADMComponent)
+    MultinomialRandomEffectsModelAlignmentADMComponent,
+    TournamentRandomEffectsModelAlignmentADMComponent,
+)
 
 @pytest.mark.parametrize(
     ("alignment_fn_class"),
@@ -1657,3 +1659,388 @@ class TestMultinomialRandomEffectsModelAlignmentADMComponent:
             pytest.approx(exp_value)
         )
         assert np.isclose(1, np.sum(exp_value))
+
+
+class TestTournamentRandomEffectsModelAlignmentADMComponent:
+    attribute_definitions = {
+        "KDMA_A": {
+            "name": "Merit Focus",
+            "kdma": "merit",
+            "description": "Test merit focus KDMA",
+        },
+        "KDMA_B": {
+            "name": "Affiliation Focus",
+            "kdma": "affiliation",
+            "description": "Test affiliation focus KDMA",
+        },
+        "KDMA_C": {
+            "name": "Personal Safety",
+            "kdma": "personal_safety",
+            "description": "Test personal safety KDMA",
+        },
+        "KDMA_D": {
+            "name": "Search vs Stay",
+            "kdma": "search",
+            "description": "Test search vs stay KDMA",
+        },
+    }
+
+    @pytest.mark.parametrize(
+        ("attribute_prediction_scores", "attribute_relevance", "alignment_target", "exp_choice", "exp_raises"),
+        [
+            # No alignment target
+            (
+                {
+                    "Choice 0": {"medical": 0.1, "KDMA_A": 0.1, "KDMA_B": 0.8},
+                    "Choice 1": {"medical": 0.6, "KDMA_A": 0.3, "KDMA_B": 0.5},
+                },
+                None,
+                None,
+                None,  # Raise expected so doesn't matter
+                pytest.raises(RuntimeError, match=r"Assumption violated: `alignment_target` was None"),
+            ),
+            # No medical predictions
+            (
+                {
+                    "Choice 0": {"KDMA_A": 0.1, "KDMA_B": 0.8},
+                    "Choice 1": {"KDMA_A": 0.3, "KDMA_B": 0.5},
+                },
+                None,
+                {
+                    "kdma_values":
+                    [
+                        {
+                            "kdma": "KDMA_A",
+                            "value": None,
+                            "parameters": [
+                                {"name": "intercept", "value": 0.75},
+                                {"name": "medical_weight", "value": 0.5},
+                                {"name": "attr_weight", "value": -0.25},
+                            ]
+                        },
+                    ],
+                },
+                None,  # Raise expected so doesn't matter
+                pytest.raises(RuntimeError, match=r"Medical Urgency predictions required"),
+            ),
+            # Target missing parameters
+            (
+                {
+                    "Choice 0": {"medical": 0.9, "KDMA_A": 0.1},
+                    "Choice 1": {"medical": 0.4, "KDMA_A": 0.9},
+                },
+                None,
+                {
+                    "kdma_values": [{"kdma": "KDMA_A", "value": 0.7}],
+                },
+                None,  # Raise expected so doesn't matter
+                pytest.raises(RuntimeError, match=r"This alignment function requires an intercept, medical weight, and attr weight"),
+            ),
+            # Target missing intercept
+            (
+                {
+                    "Choice 0": {"medical": 0.9, "KDMA_A": 0.1},
+                    "Choice 1": {"medical": 0.4, "KDMA_A": 0.9},
+                },
+                None,
+                {
+                    "kdma_values": [
+                        {
+                            "kdma": "KDMA_A",
+                            "value": None,
+                            "parameters": [
+                                {"name": "medical_weight", "value": 0.5},
+                                {"name": "attr_weight", "value": -0.25},
+                            ]
+                        }
+                    ],
+                },
+                None,  # Raise expected so doesn't matter
+                pytest.raises(RuntimeError, match=r"This alignment function requires an intercept, medical weight, and attr weight"),
+            ),
+            # Target missing medical weight
+            (
+                {
+                    "Choice 0": {"medical": 0.9, "KDMA_A": 0.1},
+                    "Choice 1": {"medical": 0.4, "KDMA_A": 0.9},
+                },
+                None,
+                {
+                    "kdma_values": [
+                        {
+                            "kdma": "KDMA_A",
+                            "value": None,
+                            "parameters": [
+                                {"name": "intercept", "value": 0.75},
+                                {"name": "attr_weight", "value": -0.25},
+                            ]
+                        }
+                    ],
+                },
+                None,  # Raise expected so doesn't matter
+                pytest.raises(RuntimeError, match=r"This alignment function requires an intercept, medical weight, and attr weight"),
+            ),
+            # Target missing attr_weight
+            (
+                {
+                    "Choice 0": {"medical": 0.9, "KDMA_A": 0.1},
+                    "Choice 1": {"medical": 0.4, "KDMA_A": 0.9},
+                },
+                None,
+                {
+                    "kdma_values": [
+                        {
+                            "kdma": "KDMA_A",
+                            "value": None,
+                            "parameters": [
+                                {"name": "intercept", "value": 0.75},
+                                {"name": "medical_weight", "value": 0.5},
+                            ]
+                        }
+                    ],
+                },
+                None,  # Raise expected so doesn't matter
+                pytest.raises(RuntimeError, match=r"This alignment function requires an intercept, medical weight, and attr weight"),
+            ),
+            # Multiple KDMAs relevant
+            (
+                {
+                    "Choice 0": {"medical": 0.9, "KDMA_A": 0.1},
+                    "Choice 1": {"medical": 0.4, "KDMA_A": 0.9},
+                },
+                None,
+                {
+                    "kdma_values": [
+                        {
+                            "kdma": "KDMA_A",
+                            "value": None,
+                            "parameters": [
+                                {"name": "intercept", "value": 0.75},
+                                {"name": "medical_weight", "value": 0.5},
+                                {"name": "attr_weight", "value": -0.25},
+                            ]
+                        },
+                        {
+                            "kdma": "KDMA_B",
+                            "value": None,
+                            "parameters": [
+                                {"name": "intercept", "value": 0.75},
+                                {"name": "medical_weight", "value": 0.5},
+                                {"name": "attr_weight", "value": -0.25},
+                            ]
+                        }
+                    ],
+                },
+                None,  # Raise expected so doesn't matter
+                pytest.raises(RuntimeError, match=r"This alignment function can only be used when 1 attribute is relevant"),
+            ),
+            # Worked example with ADEPT
+            (
+                {
+                    "Treat Patient A": {"medical": 0.947157191, "merit": 0.0},
+                    "Treat Patient B": {"medical": 0.012495865, "merit": 1.0},
+                    # Medical delta = 0.947157191-0.012495865 = 0.934661326
+                    # Z-scaled medical delta = (0.934661326 - 0.428961) / 0.301250 = 1.67867328133
+                    # Attribute score = 0.0
+                    # Z-scaled attribute = (0.0 - 0.337618) / 0.272520 = -1.23887421107
+                },
+                None,
+                {
+                    "kdma_values": [
+                        {
+                            "kdma": "KDMA_A",
+                            "value": None,
+                            "parameters": [
+                                {"name": "intercept", "value": 0.5},
+                                {"name": "medical_weight", "value": 0.85},
+                                {"name": "attr_weight", "value": -0.3},
+                            ]
+                        },
+                    ],
+                    # Y_ij = 0.5 + 0.85*1.67867328133-0.3*-1.23887421107 = 2.29853455245
+                    # P_choose_a = e^2.29853455245/(1+e^2.29853455245) = 0.90875559851
+                },
+                "Treat Patient A",
+                does_not_raise(),
+            ),
+            # Multi-KDMA, should fallback to merit
+            (
+                {
+                    "Treat Patient A": {"medical": 0.947157191, "merit": 0.0, "affiliation": 0.5},
+                    "Treat Patient B": {"medical": 0.012495865, "merit": 1.0, "affiliation": 0.25},
+                    # Medical delta = 0.947157191-0.012495865 = 0.934661326
+                    # Z-scaled medical delta = (0.934661326 - 0.428961) / 0.301250 = 1.67867328133
+                    # Attribute score = 0.0
+                    # Z-scaled attribute = (0.0 - 0.337618) / 0.272520 = -1.23887421107
+                },
+                {
+                    "merit": 1.0,
+                    "affiliation": 0.0
+                },
+                {
+                    "kdma_values": [
+                        {
+                            "kdma": "KDMA_A",
+                            "value": None,
+                            "parameters": [
+                                {"name": "intercept", "value": 0.5},
+                                {"name": "medical_weight", "value": 0.85},
+                                {"name": "attr_weight", "value": -0.3},
+                            ]
+                        },
+                        {
+                            "kdma": "KDMA_B",
+                            "value": None,
+                            "parameters": [
+                                {"name": "intercept", "value": 0.75},
+                                {"name": "medical_weight", "value": 0.5},
+                                {"name": "attr_weight", "value": -0.25},
+                            ]
+                        }
+                    ],
+                    # Y_ij = 0.5 + 0.85*1.67867328133-0.3*-1.23887421107 = 2.29853455245
+                    # P_choose_a = e^2.29853455245/(1+e^2.29853455245) = 0.90875559851
+                },
+                "Treat Patient A",
+                does_not_raise(),
+            ),
+            # <2 choices
+            (
+                {
+                    "Choice 0": {"medical": 0.1, "KDMA_B": 0.8},
+                },
+                None,
+                {
+                   "kdma_values":
+                    [
+                        {
+                            "kdma": "KDMA_A",
+                            "value": None,
+                            "parameters": [
+                                {"name": "intercept", "value": 0.75},
+                                {"name": "medical_weight", "value": 0.5},
+                                {"name": "attr_weight", "value": -0.25},
+                            ]
+                        },
+                    ],
+                },
+                "Choice 0",
+                does_not_raise(),
+            ),
+            # >2 choices
+            (
+                {
+                    "Choice 0": {"medical": 0.1, "merit": 0.2},
+                    "Choice 1": {"medical": 0.2, "merit": 0.1},
+                    "Choice 2": {"medical": 0.9, "merit": 0.9},
+                },
+                None,
+                {
+                    "kdma_values":
+                    [
+                        {
+                            "kdma": "KDMA_A",
+                            "value": None,
+                            "parameters": [
+                                {"name": "intercept", "value": 0.75},
+                                {"name": "medical_weight", "value": 0.5},
+                                {"name": "attr_weight", "value": -0.25},
+                            ]
+                        },
+                    ],
+                },
+                "Choice 2",  # Choice 2 wins for both medical and attribute
+                does_not_raise(),
+            ),
+        ],
+        ids=[
+            "no target", "no medical preds", "target missing parameters", "missing intercept", "missing medical weight",
+            "missing attr weight", "multiple relevant KDMAs", "worked example", "multi-kdma", "<2 choices", ">2 choices",
+        ],
+    )
+    def test_run(self, attribute_prediction_scores, attribute_relevance, alignment_target, exp_choice, exp_raises):
+        alignment_fn = TournamentRandomEffectsModelAlignmentADMComponent(
+            TestTournamentRandomEffectsModelAlignmentADMComponent.attribute_definitions
+        )
+
+        with exp_raises:
+            # Only checking selected choice as best sample index not yet implemented
+            assert alignment_fn.run(attribute_prediction_scores, alignment_target, attribute_relevance)[0] == exp_choice
+
+    @pytest.mark.parametrize(
+        ("p_matrix", "exp_value"),
+        [
+            (
+                np.array([[1, 0.25, 0.6], [0.75, 1, 0.8], [0.4, 0.2, 1]]),
+                np.array([[0, -1.09861228867, 0.4054651081], [1.09861228867, 0, 1.38629436112], [-0.4054651081, -1.38629436112, 0]])
+            ),
+            (
+                np.array([[1, 0.55, 0.36], [0.45, 1, 0.24], [0.64, 0.76, 1]]),
+                np.array([[0, 0.20067069546, -0.5753641449], [-0.20067069546, 0, -1.15267950994], [0.5753641449, 1.15267950994, 0]])
+            ),
+            (
+                np.array([[1, 0.6, 0.6], [0.4, 1, 0.6], [0.4, 0.4, 1]]),
+                np.array([[0, 0.4054651081, 0.4054651081], [-0.4054651081, 0, 0.4054651081], [-0.4054651081, -0.4054651081, 0]])
+            ),
+            (
+                np.array([[1, 0.6, 0.6, 0.5], [0.4, 1, 0.6, 0.5], [0.4, 0.4, 1, 0.5], [0.5, 0.5, 0.5, 1]]),
+                np.array([[0, 0.4054651081, 0.4054651081, 0], [-0.4054651081, 0, 0.4054651081, 0], [-0.4054651081, -0.4054651081, 0, 0], [0, 0, 0, 0]])
+            )
+        ],
+    )
+    def test_log_odds(self, p_matrix, exp_value):
+        alignment_fn = TournamentRandomEffectsModelAlignmentADMComponent(
+            TestTournamentRandomEffectsModelAlignmentADMComponent.attribute_definitions
+        )
+
+        assert np.allclose(alignment_fn._log_odds(p_matrix), exp_value)
+
+
+    @pytest.mark.parametrize(
+        ("scores", "exp_value"),
+        [
+            (
+                np.array([0.6, -0.3, 0.4]),
+                np.array([0.44937752864, 0.18270326891, 0.36791920244])
+            ),
+            (
+                np.array([0.6, -0.3, 0.4, -0.8]),
+                np.array([0.40454753882, 0.16447675521, 0.33121551111, 0.09976019484])
+            ),
+            (
+                np.array([-0.69314718057, 2.48490664979, -1.79175946922]),
+                np.array([0.03947368421, 0.94736842105, 0.01315789473])
+            ),
+            (
+                np.array([-0.37469344944, -1.3533502054, 1.72804365484]),
+                np.array([0.10455474162, 0.03929330002, 0.85615195834])
+            ),
+        ],
+    )
+    def test_softmax(self, scores, exp_value):
+        alignment_fn = TournamentRandomEffectsModelAlignmentADMComponent(
+            TestTournamentRandomEffectsModelAlignmentADMComponent.attribute_definitions
+        )
+
+        assert np.allclose(alignment_fn._stable_softmax(scores), exp_value)
+        assert np.isclose(1, np.sum(exp_value))
+
+    @pytest.mark.parametrize(
+        ("p_matrix", "exp_value"),
+        [
+            (
+                np.array([[1, 0.25, 0.6], [0.75, 1, 0.8], [0.4, 0.2, 1]]),
+                np.array([0.03947368421, 0.94736842105, 0.01315789473])
+            ),
+            (
+                np.array([[1, 0.55, 0.36], [0.45, 1, 0.24], [0.64, 0.76, 1]]),
+                np.array([0.10455474162, 0.03929330002, 0.85615195834])
+            )
+        ],
+    )
+    def test_composite_probs(self, p_matrix, exp_value):
+        alignment_fn = TournamentRandomEffectsModelAlignmentADMComponent(
+            TestTournamentRandomEffectsModelAlignmentADMComponent.attribute_definitions
+        )
+
+        assert np.allclose(alignment_fn._composite_probs(p_matrix), exp_value)

--- a/align_system/tests/test_alignment_adm_component.py
+++ b/align_system/tests/test_alignment_adm_component.py
@@ -1839,10 +1839,14 @@ class TestTournamentRandomEffectsModelAlignmentADMComponent:
                 {
                     "Treat Patient A": {"medical": 0.947157191, "merit": 0.0},
                     "Treat Patient B": {"medical": 0.012495865, "merit": 1.0},
-                    # Medical delta = 0.947157191-0.012495865 = 0.934661326
-                    # Z-scaled medical delta = (0.934661326 - 0.428961) / 0.301250 = 1.67867328133
-                    # Attribute score = 0.0
-                    # Z-scaled attribute = (0.0 - 0.337618) / 0.272520 = -1.23887421107
+                    # Z-scale Patient A:
+                    #   med: (0.947157191 - 0.576) /  0.339 = 1.0948589705
+                    #   attr: (0.0 - 0.671) / 0.381 = -1.76115485564
+                    # Z-scale Patient B:
+                    #   med: (0.012495865 - 0.576) /  0.339 = -1.66225408555
+                    #   attr: (1.0 - 0.671) / 0.381 = 0.86351706036
+                    # Medical delta = 1.0948589705 - -1.66225408555 = 2.75711305605
+                    # Attr delta = -1.76115485564 - 0.86351706036 = -2.624671916
                 },
                 None,
                 {
@@ -1857,8 +1861,8 @@ class TestTournamentRandomEffectsModelAlignmentADMComponent:
                             ]
                         },
                     ],
-                    # Y_ij = 0.5 + 0.85*1.67867328133-0.3*-1.23887421107 = 2.29853455245
-                    # P_choose_a = e^2.29853455245/(1+e^2.29853455245) = 0.90875559851
+                    # Y_ij = 0.5 + 0.85*2.75711305605-0.3*-2.624671916 = 3.63094767244
+                    # P_choose_a = e^3.63094767244/(1+e^3.63094767244) = 0.97419259797
                 },
                 "Treat Patient A",
                 does_not_raise(),
@@ -1868,10 +1872,14 @@ class TestTournamentRandomEffectsModelAlignmentADMComponent:
                 {
                     "Treat Patient A": {"medical": 0.947157191, "merit": 0.0, "affiliation": 0.5},
                     "Treat Patient B": {"medical": 0.012495865, "merit": 1.0, "affiliation": 0.25},
-                    # Medical delta = 0.947157191-0.012495865 = 0.934661326
-                    # Z-scaled medical delta = (0.934661326 - 0.428961) / 0.301250 = 1.67867328133
-                    # Attribute score = 0.0
-                    # Z-scaled attribute = (0.0 - 0.337618) / 0.272520 = -1.23887421107
+                    # Z-scale Patient A:
+                    #   med: (0.947157191 - 0.576) /  0.339 = 1.0948589705
+                    #   attr: (0.0 - 0.671) / 0.381 = -1.76115485564
+                    # Z-scale Patient B:
+                    #   med: (0.012495865 - 0.576) /  0.339 = -1.66225408555
+                    #   attr: (1.0 - 0.671) / 0.381 = 0.86351706036
+                    # Medical delta = 1.0948589705 - -1.66225408555 = 2.75711305605
+                    # Attr delta = -1.76115485564 - 0.86351706036 = -2.624671916
                 },
                 {
                     "merit": 1.0,
@@ -1898,8 +1906,8 @@ class TestTournamentRandomEffectsModelAlignmentADMComponent:
                             ]
                         }
                     ],
-                    # Y_ij = 0.5 + 0.85*1.67867328133-0.3*-1.23887421107 = 2.29853455245
-                    # P_choose_a = e^2.29853455245/(1+e^2.29853455245) = 0.90875559851
+                    # Y_ij = 0.5 + 0.85*2.75711305605-0.3*-2.624671916 = 3.63094767244
+                    # P_choose_a = e^3.63094767244/(1+e^3.63094767244) = 0.97419259797
                 },
                 "Treat Patient A",
                 does_not_raise(),

--- a/align_system/utils/incontext_utils.py
+++ b/align_system/utils/incontext_utils.py
@@ -887,3 +887,80 @@ class Phase2ComparativeRegressionIncontextExampleGenerator(IncontextExampleGener
 
         cot_reasoning = f"{max_choice} demonstates {adjective} more {target_kdma['name']} than {min_choice}."
         return cot_reasoning
+
+# TODO: Refactor IncontextExampleGenerators to take scenario
+# description and prompt templates as arguments and use
+# `call_with_coerced_args`
+class Phase2ComparativeRegressionIncontextExampleGeneratorOWConversion(Phase2ComparativeRegressionIncontextExampleGenerator):
+    def set_icl_datasets(self):
+        from swagger_client.models import ActionTypeEnum
+
+        icl_datasets = {}
+        incontext_data = self._read_icl_dataset_files()
+
+        # Add each target to icl_datasets
+        for target_kdma in self.target_kdmas:
+            sys_kdma_name = target_kdma['kdma']
+            icl_datasets[sys_kdma_name] = []
+            kdma_incontext_data = incontext_data[sys_kdma_name]
+
+            # Add each examples to icl_datasets
+            for example in kdma_incontext_data:
+                character_unstructured_by_id = {c.id: c.unstructured for c in example['state'].characters}
+
+                # Get example response
+                icl_response = {}
+                included_choices = []
+                for action, choice, kdma_value in zip(example['actions'], example['choices'], example["kdma_values"]):
+                    # HACK: Reformat choice string for OW
+                    # TODO: Bring more in line with OWFormatChoicesADMComponent (align_system/algorithms/open_world_components.py)
+                    if action.action_type in {ActionTypeEnum.END_SCENE, ActionTypeEnum.SEARCH}:
+                        choice = action.unstructured
+                    else:
+                        c_id = action.character_id
+                        # Not doing action expansion here as is done
+                        # in the OWFormatChoiceADMComponent, since
+                        # it's not clear whether the ground truth
+                        # values would just be duplicated across the
+                        # expansion or??
+                        assert c_id is not None
+
+                        choice = f"{c_id}: {character_unstructured_by_id[c_id]}"
+
+                    # Only include choice if there is a ground truth KDMA value available
+                    if kdma_value is None:
+                        continue
+                    # Groundtruth KDMA values are 0-1, but ADM may predict on a different scale
+                    scaled_kdma_value = int(kdma_value * target_kdma["factor"])
+                    icl_response[choice] = {}
+                    icl_response[choice]['score'] = scaled_kdma_value
+                    included_choices.append(choice)
+                icl_response_with_reasoning={}
+                icl_response_with_reasoning['reasoning'] = self.get_chain_of_thought_reasoning(target_kdma, icl_response)
+                icl_response_with_reasoning.update(icl_response) # reasoning first
+                # Check if response is valid against json schema
+                correct_schema = json.loads(comparative_regression_json_schema(included_choices, target_kdma["factor"]))
+                validate(instance=icl_response_with_reasoning, schema=correct_schema)
+
+                # Get example prompt
+                icl_scenario_description = phase2_scenario_state_description(example['state'])
+                # Only include choices in the prompt if they are in the response
+                included_icl_choices_with_outcomes = {}
+                for choice in included_choices:
+                    # TODO: Include outcome prediction for ICL examples?
+                    included_icl_choices_with_outcomes[choice] = {'predicted_outcome':None}
+
+                icl_prompt = comparative_regression_prompt(icl_scenario_description,
+                                                           included_icl_choices_with_outcomes,
+                                                           target_kdma['name'])
+
+                # Add example
+                icl_datasets[sys_kdma_name].append({
+                    "state": example["state"],
+                    "scenario_description": icl_scenario_description,
+                    "prompt": icl_prompt,
+                    "response": icl_response_with_reasoning,
+                    "actions": example['actions']
+                    })
+
+        self.icl_datasets = icl_datasets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pytest>=9.0.2",
     "rouge-score>=0.1.2",
     "scikit-learn>=1.7.2",
-    "swagger-client==0.5.2",
+    "swagger-client==0.5.3",
     "transformers>=4.56.0,<5", # Pinned to be compatible with vllm 0.19.0
     "ubelt>=1.4.1",
     "setuptools-scm>=8.0,<9",

--- a/uv.lock
+++ b/uv.lock
@@ -2708,7 +2708,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2735,7 +2735,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2762,9 +2762,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-cusparse-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2775,7 +2775,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4647,8 +4647,8 @@ wheels = [
 
 [[package]]
 name = "swagger-client"
-version = "0.5.1"
-source = { git = "https://github.com/NextCenturyCorporation/itm-evaluation-client.git#2e2351d016225887e0f9f95abf244b11dad32370" }
+version = "0.5.3"
+source = { git = "https://github.com/NextCenturyCorporation/itm-evaluation-client.git#c4cb122676732492bd20fdcd76afa217987039dd" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dateutil" },


### PR DESCRIPTION
Rebased version of [!283](https://github.com/ITM-Kitware/align-system/pull/283), includes changes from [!273](https://github.com/ITM-Kitware/align-system/pull/273)

See the description from those below:

- Fixes unit tests broken by merit focus weight modification from ADEPT 2026-01-21
- We weren't finding that medical urgency/KDMA(s) varied across actions for the same character.So, we are now regressing based on character descriptions only (or non-character actions, but that doesn't really apply due to the available actions). [OWFormatChoicesADMComponent, then CR/DR]
- We use alignment to pick the highest ranked character (or non-character action) [Existing alignment function].
- That character may correspond to multiple actions, so we then have a secondary non-aligned prompt to choose which sub action to do. [OWChoiceToActionADMComponent]
- Once we've picked a single action, we may have details to fill in like tag color or character ID, so we then do that with followups (again, not aligned) [OWActionParameterCompletionADMComponent]
- Then finally, we do a tag adjustment based on a heuristic to "align" tag color. [OWTaggingAdjustmentADMComponent]. I didn't want to name this component alignment because it doesn't directly use the alignment target. Instead it considers the KDMA ranking vs medical only ranking as well as how other patients have been tagged so far